### PR TITLE
WIP: A first stab at analytic opacities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,16 @@ target_compile_options(singularity-opac::flags INTERFACE
 target_link_options(singularity-opac::flags INTERFACE
                    $<$<COMPILE_LANG_AND_ID:CXX,XL>:-std=c++1y;-qxflag=disable__cplusplusOverride>)
 
+# Base Include directories
+target_include_directories(singularity-opac::libs
+  INTERFACE
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/utils>
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/opacities>)
+target_include_directories(singularity-opac::flags
+  INTERFACE
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/utils>
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/opacities>)
+
 # check for currently incompatible option
 if(SINGULARITY_USE_CUDA AND NOT SINGULARITY_USE_KOKKOS)
   message(FATAL_ERROR "Cuda without kokkos is not currently supported")

--- a/opacities/gray_opacity.hpp
+++ b/opacities/gray_opacity.hpp
@@ -1,0 +1,90 @@
+// ======================================================================
+// © 2021. Triad National Security, LLC. All rights reserved.  This
+// program was produced under U.S. Government contract
+// 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
+// is operated by Triad National Security, LLC for the U.S.
+// Department of Energy/National Nuclear Security Administration. All
+// rights in the program are reserved by Triad National Security, LLC,
+// and the U.S. Department of Energy/National Nuclear Security
+// Administration. The Government is granted for itself and others
+// acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works,
+// distribute copies to the public, perform publicly and display
+// publicly, and to permit others to do so.
+// ======================================================================
+
+#ifndef OPACITIES_GRAY_EMISSIVITY
+#define OPACITIES_GRAY_EMISSIVITY
+
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+
+#include <opac-utils/opac_error.hpp>
+#include <opac-utils/physical_constants.hpp>
+#include <ports-of-call/portability.hpp>
+
+#include "thermal_distributions.hpp"
+
+namespace singularity {
+
+template <typename ThermalDistribution, int NSPECIES> class GrayOpacity {
+public:
+  GrayOpacity(const Real kappa) : kappa_(kappa) {}
+  GrayOpacity(const ThermalDistribution &dist, const Real kappa)
+      : dist_(dist), kappa_(kappa) {}
+
+  GrayOpacity GetOnDevice() { return *this; }
+  PORTABLE_INLINE_FUNCTION
+  int nlambda() const noexcept { return 1; }
+  PORTABLE_INLINE_FUNCTION
+  void PrintParams() const noexcept {
+    printf("Gray opacity. kappa = %g\n", kappa_);
+  }
+  inline void Finalize() noexcept {}
+
+  // TODO(JMM): Does this make sense for the tophat?
+  PORTABLE_INLINE_FUNCTION
+  Real OpacityPerNu(const RadiationType type, const Real rho, const Real temp,
+                    const Real nu, Real *lambda = nullptr) {
+    return OpacityFromKirkhoff(*this, dist_);
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real EmissivityPerNuOmega(const RadiationType type, const Real rho,
+                            const Real temp, const Real nu,
+                            Real *lambda = nullptr) {
+    Real Bnu = dist_.ThermalDistributionOfTNu(temp, nu);
+    return kappa_ * Bnu;
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real EmissivityPerNu(const RadiationType type, const Real rho,
+                       const Real temp, const Real nu,
+                       const Real *lambda = nullptr) {
+    return 4 * M_PI * EmissivityPerNuOmega(type, rho, temp, nu, lambda);
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real Emissivity(const RadiationType type, const Real rho, const Real temp,
+                  Real *lambda = nullptr) {
+    return kappa_ * dist_.ThermalDistributionOfT(temp);
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real NumberEmissivity(RadiationType type, const Real rho, const Real temp,
+                        Real *lambda = nullptr) {
+    using namespace constants;
+    constexpr Real zeta3 = 1.20206;
+    return 12. * pow(cgs::KBOL, 3) * M_PI * NSPECIES * pow(temp, 3) * kappa_ *
+           zeta3 / (pow(cgs::CL, 2) * pow(cgs::HPL, 3));
+  }
+
+private:
+  Real kappa_; // absorption coefficient. Units of 1/cm
+  ThermalDistribution dist_;
+};
+
+} // namespace singularity
+
+#endif //  OPACITIES_GRAY_EMISSIVITY

--- a/opacities/opac.hpp
+++ b/opacities/opac.hpp
@@ -16,10 +16,20 @@
 #ifndef OPACITIES_OPAC_
 #define OPACITIES_OPAC_
 
+#include "gray_opacity.hpp"
+#include "opac_variant.hpp"
+#include "thermal_distributions.hpp"
+#include "tophat_emissivity.hpp"
 
 namespace singularity {
 
+using GrayPhotonOpacity = GrayOpacity<PlanckDistribution<1>, 1>;
+// TODO(JMM): Change this to Fermi-Dirac
+using GrayNeutrinoOpacity = GrayOpacity<PlanckDistribution<3>, 3>;
+using TophatOpacity = TophatEmissivity<PlanckDistribution<3>>;
 
+using Opacity =
+    opac_impl::Variant<GrayPhotonOpacity, GrayNeutrinoOpacity, TophatOpacity>;
 
 } // namespace singularity
 

--- a/opacities/opac_variant.hpp
+++ b/opacities/opac_variant.hpp
@@ -16,10 +16,10 @@
 #ifndef OPACITIES_OPAC_VARIANT_HPP_
 #define OPACITIES_OPAC_VARIANT_HPP_
 
+#include "../utils/opac_utils/opac_error.hpp"
+#include "../utils/opac_utils/radiation_types.hpp"
 #include "../utils/ports-of-call/portability.hpp"
 #include "../utils/variant/include/mpark/variant.hpp"
-
-using Real = double;
 
 namespace singularity {
 
@@ -66,23 +66,79 @@ public:
         opac_);
   }
 
+  // opacity
   PORTABLE_INLINE_FUNCTION
-  int nlambda() const noexcept {
-    return mpark::visit([](const auto &eos) { return eos.nlambda(); }, eos_);
+  OpacityPerNu(const Real rho, const Real temp, const Real nu,
+               const RadiationType type, Real *lambda = nullptr) {
+    mpark::visit(
+        [=](const auto &opac) {
+          return opac.OpacityPerNu(rho, temp, nu, type, lambda);
+        },
+        opac_);
+  }
+
+  // emissivity with units of energy/time/frequency/volume/angle
+  PORTABLE_INLINE_FUNCTION
+  EmissivityPerNuOmega(const Real rho, const Real temp, const Real nu,
+                       const RadiationType type, Real *lambda = nullptr) {
+    mpark::visit(
+        [=](const auto &opac) {
+          return opac.EmissivityPerNuOmega(rho, temp, nu, type, lambda);
+        },
+        opac_);
+  }
+
+  // emissivity integrated over angle
+  PORTABLE_INLINE_FUNCTION
+  EmissivityPerNu(const Real rho, const Real temp, const Real nu,
+                  const RadiationType type, Real *lambda = nullptr) {
+    mpark::visit(
+        [=](const auto &opac) {
+          return opac.EmissivityPerNu(rho, temp, nu, type, lambda);
+        },
+        opac_);
+  }
+
+  // emissivity integrated over angle and frequency
+  PORTABLE_INLINE_FUNCTION
+  Emissivity(const Real rho, const Real temp, const RadiationType type,
+             Real *lambda = nullptr) {
+    mpark::visit(
+        [=](const auto &opac) {
+          return opac.Emissivity(rho, temp, type, lambda);
+        },
+        opac_);
+  }
+
+  // Emissivity of packet
+  PORTABLE_INLINE_FUNCTION
+  NumberEmissivity(const Real rho, const Real temp, RadiationType type,
+                   Real *lambda = nullptr) {
+    mpark::visit(
+        [=](const auto &opac) {
+          return opac.NumberEmissivity(rho, temp, type, lambda);
+        },
+        opac_);
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  int GetNLambda() const noexcept {
+    return mpark::visit([](const auto &opac) { return opac.GetNLambda(); },
+                        opac_);
   }
 
   template <typename T> PORTABLE_INLINE_FUNCTION bool IsType() const noexcept {
-    return mpark::holds_alternative<T>(eos_);
+    return mpark::holds_alternative<T>(opac_);
   }
 
   PORTABLE_INLINE_FUNCTION
   void PrintParams() const noexcept {
-    return mpark::visit([](const auto &eos) { return eos.PrintParams(); },
-                        eos_);
+    return mpark::visit([](const auto &opac) { return opac.PrintParams(); },
+                        opac_);
   }
 
   inline void Finalize() noexcept {
-    return mpark::visit([](auto &eos) { return eos.Finalize(); }, eos_);
+    return mpark::visit([](auto &opac) { return opac.Finalize(); }, opac_);
   }
 }
 

--- a/opacities/opac_variant.hpp
+++ b/opacities/opac_variant.hpp
@@ -16,12 +16,14 @@
 #ifndef OPACITIES_OPAC_VARIANT_HPP_
 #define OPACITIES_OPAC_VARIANT_HPP_
 
-#include "../utils/opac_utils/opac_error.hpp"
-#include "../utils/opac_utils/radiation_types.hpp"
-#include "../utils/ports-of-call/portability.hpp"
-#include "../utils/variant/include/mpark/variant.hpp"
+#include <opac-utils/opac_error.hpp>
+#include <opac-utils/radiation_types.hpp>
+#include <ports-of-call/portability.hpp>
+#include <variant/include/mpark/variant.hpp>
 
 namespace singularity {
+
+namespace opac_impl {
 
 template <typename... Ts> using opac_variant = mpark::variant<Ts...>;
 
@@ -62,14 +64,14 @@ public:
 
   Variant GetOnDevice() {
     return mpark::visit(
-        [](auto &opac) { return opac_variant<OPACs...>(opac.GetOnDevice()); },
+        [](auto &opac) { return opac_variant<Opacs...>(opac.GetOnDevice()); },
         opac_);
   }
 
   // opacity
   PORTABLE_INLINE_FUNCTION
-  OpacityPerNu(const Real rho, const Real temp, const Real nu,
-               const RadiationType type, Real *lambda = nullptr) {
+  Real OpacityPerNu(const RadiationType type, const Real rho, const Real temp,
+                    const Real nu, Real *lambda = nullptr) {
     mpark::visit(
         [=](const auto &opac) {
           return opac.OpacityPerNu(rho, temp, nu, type, lambda);
@@ -79,8 +81,9 @@ public:
 
   // emissivity with units of energy/time/frequency/volume/angle
   PORTABLE_INLINE_FUNCTION
-  EmissivityPerNuOmega(const Real rho, const Real temp, const Real nu,
-                       const RadiationType type, Real *lambda = nullptr) {
+  Real EmissivityPerNuOmega(const RadiationType type, const Real rho,
+                            const Real temp, const Real nu,
+                            Real *lambda = nullptr) {
     mpark::visit(
         [=](const auto &opac) {
           return opac.EmissivityPerNuOmega(rho, temp, nu, type, lambda);
@@ -90,8 +93,8 @@ public:
 
   // emissivity integrated over angle
   PORTABLE_INLINE_FUNCTION
-  EmissivityPerNu(const Real rho, const Real temp, const Real nu,
-                  const RadiationType type, Real *lambda = nullptr) {
+  Real EmissivityPerNu(const RadiationType type, const Real rho,
+                       const Real temp, const Real nu, Real *lambda = nullptr) {
     mpark::visit(
         [=](const auto &opac) {
           return opac.EmissivityPerNu(rho, temp, nu, type, lambda);
@@ -101,8 +104,8 @@ public:
 
   // emissivity integrated over angle and frequency
   PORTABLE_INLINE_FUNCTION
-  Emissivity(const Real rho, const Real temp, const RadiationType type,
-             Real *lambda = nullptr) {
+  Real Emissivity(const RadiationType type, const Real rho, const Real temp,
+                  Real *lambda = nullptr) {
     mpark::visit(
         [=](const auto &opac) {
           return opac.Emissivity(rho, temp, type, lambda);
@@ -112,8 +115,8 @@ public:
 
   // Emissivity of packet
   PORTABLE_INLINE_FUNCTION
-  NumberEmissivity(const Real rho, const Real temp, RadiationType type,
-                   Real *lambda = nullptr) {
+  Real NumberEmissivity(RadiationType type, const Real rho, const Real temp,
+                        Real *lambda = nullptr) {
     mpark::visit(
         [=](const auto &opac) {
           return opac.NumberEmissivity(rho, temp, type, lambda);
@@ -122,9 +125,8 @@ public:
   }
 
   PORTABLE_INLINE_FUNCTION
-  int GetNLambda() const noexcept {
-    return mpark::visit([](const auto &opac) { return opac.GetNLambda(); },
-                        opac_);
+  int nlambda() const noexcept {
+    return mpark::visit([](const auto &opac) { return opac.nlambda(); }, opac_);
   }
 
   template <typename T> PORTABLE_INLINE_FUNCTION bool IsType() const noexcept {
@@ -140,8 +142,9 @@ public:
   inline void Finalize() noexcept {
     return mpark::visit([](auto &opac) { return opac.Finalize(); }, opac_);
   }
-}
+};
 
+} // namespace opac_impl
 } // namespace singularity
 
 #endif

--- a/opacities/thermal_distributions.hpp
+++ b/opacities/thermal_distributions.hpp
@@ -1,0 +1,57 @@
+// ======================================================================
+// © 2021. Triad National Security, LLC. All rights reserved.  This
+// program was produced under U.S. Government contract
+// 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
+// is operated by Triad National Security, LLC for the U.S.
+// Department of Energy/National Nuclear Security Administration. All
+// rights in the program are reserved by Triad National Security, LLC,
+// and the U.S. Department of Energy/National Nuclear Security
+// Administration. The Government is granted for itself and others
+// acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works,
+// distribute copies to the public, perform publicly and display
+// publicly, and to permit others to do so.
+// ======================================================================
+
+#ifndef OPACITIES_THERMAL_DISTRIBUTIONS
+#define OPACITIES_THERMAL_DISTRIBUTIONS
+
+#include <cmath>
+
+#include <opac-utils/physical_constants.hpp>
+#include <opac-utils/radiation_types.hpp>
+#include <ports-of-call/portability.hpp>
+
+namespace singularity {
+
+template <int NSPECIES> struct PlanckDistribution {
+  PORTABLE_INLINE_FUNCTION
+  static Real ThermalDistributionOfTNu(const Real temp, const Real nu) {
+    using namespace constants;
+    Real x = cgs::HPL * nu / (cgs::KBOL * temp);
+    Real Bnu = NSPECIES * (2. * cgs::HPL * nu * nu * nu / (cgs::CL * cgs::CL)) *
+               1. / (std::exp(x) + 1.);
+    return Bnu;
+  }
+  PORTABLE_INLINE_FUNCTION
+  static Real ThermalDistributionOfT(const Real temp) {
+    using namespace constants;
+    return 8. * std::pow(M_PI, 5) * std::pow(cgs::KBOL, 4) * NSPECIES *
+           std::pow(temp, 4) /
+           (15. * std::pow(cgs::CL, 2) * std::pow(cgs::HPL, 3));
+  }
+};
+
+template <typename Emissivity, typename ThermalDistribution>
+Real OpacityFromKirkhoff(Emissivity &J, ThermalDistribution &B,
+                         const RadiationType type,
+                         const Real rho, const Real temp, const Real nu,
+                         Real *lambda=nullptr) {
+  Real Bnu = B.ThermalDistributionOfTNu(temp, nu);
+  Real jnu = J.EmissivityPerNuOmega(type, rho, temp, nu, lambda);
+  return jnu / Bnu;
+}
+
+} // namespace singularity
+
+#endif // OPACITIES_THERMAL_DISTRIBUTIONS

--- a/opacities/tophat_emissivity.hpp
+++ b/opacities/tophat_emissivity.hpp
@@ -1,0 +1,122 @@
+// ======================================================================
+// © 2021. Triad National Security, LLC. All rights reserved.  This
+// program was produced under U.S. Government contract
+// 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
+// is operated by Triad National Security, LLC for the U.S.
+// Department of Energy/National Nuclear Security Administration. All
+// rights in the program are reserved by Triad National Security, LLC,
+// and the U.S. Department of Energy/National Nuclear Security
+// Administration. The Government is granted for itself and others
+// acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works,
+// distribute copies to the public, perform publicly and display
+// publicly, and to permit others to do so.
+// ======================================================================
+
+#ifndef OPACITIES_TOPHAT_EMISSIVITY
+#define OPACITIES_TOPHAT_EMISSIVITY
+
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+
+#include <opac-utils/opac_error.hpp>
+#include <opac-utils/physical_constants.hpp>
+#include <ports-of-call/portability.hpp>
+
+#include "thermal_distributions.hpp"
+
+namespace singularity {
+
+// Neutrino tophat emissivity from
+// Miller, Ryan, Dolence (2019). arXiv:1903.09273
+template <typename ThermalDistribution> class TophatEmissivity {
+public:
+  TophatEmissivity(const Real C, const Real numin, const Real numax)
+      : C_(C), numin_(numin), numax_(numax) {}
+  TophatEmissivity(const ThermalDistribution &dist, const Real C,
+                   const Real numin, const Real numax)
+      : dist_(dist), C_(C), numin_(numin), numax_(numax) {}
+  TophatEmissivity GetOnDevice() { return *this; }
+  PORTABLE_INLINE_FUNCTION
+  int nlambda() const noexcept { return 1; }
+  PORTABLE_INLINE_FUNCTION
+  void PrintParams() const noexcept {
+    printf("Tophat emissivity. C, numin, numax = %g, %g, %g\n", C_, numin_,
+           numax_);
+  }
+  inline void Finalize() noexcept {}
+
+  // TODO(JMM): Does this make sense for the tophat?
+  PORTABLE_INLINE_FUNCTION
+  Real OpacityPerNu(const RadiationType type, const Real rho, const Real temp,
+                    const Real nu, Real *lambda = nullptr) {
+    return OpacityFromKirkhoff(*this, dist_);
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real EmissivityPerNuOmega(const RadiationType type, const Real rho,
+                            const Real temp, const Real nu,
+                            Real *lambda = nullptr) {
+    assert(type == RadiationType::NU_ELECTRON ||
+           type == RadiationType::NU_ELECTRON_ANTI ||
+           type == RadiationType::NU_HEAVY);
+    Real Ye = lambda[0];
+    if (nu > numin_ && nu < numax_) {
+      return C_ * GetYeF(Ye, type) / (4. * M_PI);
+    } else {
+      return 0.;
+    }
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real EmissivityPerNu(const RadiationType type, const Real rho,
+                       const Real temp, const Real nu,
+                       const Real *lambda = nullptr) {
+    return 4 * M_PI * EmissivityPerNuOmega(type, rho, temp, nu, lambda);
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real Emissivity(const RadiationType type, const Real rho, const Real temp,
+                  Real *lambda = nullptr) {
+    assert(type == RadiationType::NU_ELECTRON ||
+           type == RadiationType::NU_ELECTRON_ANTI ||
+           type == RadiationType::NU_HEAVY);
+    Real Ye = lambda[0];
+    Real Bc = C_ * (numax_ - numin_);
+    Real J = Bc * GetYeF(Ye, type);
+    return J;
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real NumberEmissivity(RadiationType type, const Real rho, const Real temp,
+                        Real *lambda = nullptr) {
+    using namespace constants;
+    assert(type == RadiationType::NU_ELECTRON ||
+           type == RadiationType::NU_ELECTRON_ANTI ||
+           type == RadiationType::NU_HEAVY);
+    Real Ye = lambda[0];
+    Real Ac = 1 / (cgs::HPL * rho) * C_ * log(numax_ / numin_);
+    return rho * Ac * GetYeF(Ye, type);
+  }
+
+private:
+  PORTABLE_INLINE_FUNCTION
+  Real GetYeF(Real Ye, RadiationType type) {
+    if (type == RadiationType::NU_ELECTRON) {
+      return 2. * Ye;
+    } else if (type == RadiationType::NU_ELECTRON_ANTI) {
+      return 1. - 2. * Ye;
+    } else {
+      return 0.;
+    }
+  }
+  Real C_;
+  Real numin_;
+  Real numax_;
+  ThermalDistribution dist_;
+};
+
+} // namespace singularity
+
+#endif // OPACITIES_TOPHAT_EMISSIVITY

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,6 +17,7 @@ target_link_libraries(catch2_define PUBLIC
 
 list(APPEND unit_tests_SOURCES
   test_trivial.cpp
+  test_gray_opacities.cpp
 )
 
 add_executable(unit_tests "${unit_tests_SOURCES}")

--- a/test/test_gray_opacities.cpp
+++ b/test/test_gray_opacities.cpp
@@ -13,39 +13,15 @@
 // publicly, and to permit others to do so.
 // ======================================================================
 
-#ifndef UTILS_OPAC_UTILS_RADIATION_TYPES
-#define UTILS_OPAC_UTILS_RADIATION_TYPES
+#include <catch2/catch.hpp>
 
-#include "opac_error.hpp"
+#include "../opacities/opac.hpp"
 
-namespace singularity {
+using namespace singularity;
 
-enum class RadiationType {
-  TRACER = -1,
-  NU_ELECTRON = 0,
-  NU_ELECTRON_ANTI = 1,
-  NU_HEAVY = 2,
-  PHOTON = 3
-};
-
-int RadType2Idx(RadiationType type) { return static_cast<int>(type); }
-RadiationType Idx2RadType(int i) {
-  switch (i) {
-  case -1:
-    return RadiationType::TRACER;
-  case 0:
-    return RadiationType::NU_ELECTRON;
-  case 1:
-    return RadiationType::NU_ELECTRON_ANTI;
-  case 2:
-    return RadiationType::NU_HEAVY;
-  case 3:
-    return RadiationType::PHOTON;
-  default:
-    OPAC_ERROR("Unknown radiation type");
+TEST_CASE("Gray opacities", "[GrayPhoton][GrayNeutrinos]") {
+  WHEN("We initialize a gray photon opacity") {
+    Opacity opac_photon = GrayPhotonOpacity(1);
+    Opacity opac_neutrino = GrayNeutrinoOpacity(1);
   }
 }
-
-} // namespace singularity
-
-#endif // UTILS_OPAC_UTILS_RADIATION_TYPES

--- a/utils/opac-utils/opac_error.hpp
+++ b/utils/opac-utils/opac_error.hpp
@@ -13,14 +13,20 @@
 // publicly, and to permit others to do so.
 // ======================================================================
 
-#ifndef OPACITIES_OPAC_
-#define OPACITIES_OPAC_
-
+#ifndef UTILS_OPAC_UTILS_OPAC_ERROR_
+#define UTILS_OPAC_UTILS_OPAC_ERROR_
 
 namespace singularity {
 
-
+#ifdef SINGULARITY_ENABLE_EXCEPTIONS
+#include <stdexcept>
+#define OPAC_ERROR(x) (throw std::runtime_error(x))
+#else
+#include <cstdlib>
+#define OPAC_ERROR(x) printf("%s", x); std::exit(1)
+#endif
+#define UNDEFINED_ERROR OPAC_ERROR("DEFINE ME\n")
 
 } // namespace singularity
 
-#endif // OPACITIES_OPAC_
+#endif // UTILS_OPAC_UTILS_OPAC_ERROR_

--- a/utils/opac-utils/physical_constants.hpp
+++ b/utils/opac-utils/physical_constants.hpp
@@ -1,0 +1,68 @@
+// ======================================================================
+// Copyright © 2018, University of Illinois. All rights reserved.
+// © 2021. Triad National Security, LLC. All rights reserved.  This
+// program was produced under U.S. Government contract
+// 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
+// is operated by Triad National Security, LLC for the U.S.
+// Department of Energy/National Nuclear Security Administration. All
+// rights in the program are reserved by Triad National Security, LLC,
+// and the U.S. Department of Energy/National Nuclear Security
+// Administration. The Government is granted for itself and others
+// acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works,
+// distribute copies to the public, perform publicly and display
+// publicly, and to permit others to do so.
+// ======================================================================
+
+#ifndef UTILS_OPAC_UTILS_PHYSICAL_CONSTANTS
+#define UTILS_OPAC_UTILS_PHYSICAL_CONSTANTS
+
+#include <cmath>
+#include <ports-of-call/portability.hpp>
+
+// Convention taken from ebhlight/nubhlight
+namespace singularity {
+namespace constants {
+namespace cgs {
+
+constexpr Real EE = 4.80320680e-10;       // Electron charge
+constexpr Real CL = 2.99792458e10;        // Speed of light
+constexpr Real ME = 9.1093826e-28;        // Electron mass
+constexpr Real MP = 1.67262171e-24;       // Proton mass
+constexpr Real MN = 1.67492728e-24;       // Neutron mass
+constexpr Real HPL = 6.6260693e-27;       // Planck constant
+constexpr Real HBAR = HPL / (2. * M_PI);  // Reduced Planck constant
+constexpr Real KBOL = 1.3806505e-16;      // Boltzmann constant
+constexpr Real GNEWT = 6.6742e-8;         // Gravitational constant
+constexpr Real SIG = 5.670400e-5;         // Stefan-Boltzmann constant
+constexpr Real AR = 4 * SIG / CL;         // Radiation constant
+constexpr Real THOMSON = 0.665245873e-24; // Thomson cross section
+constexpr Real COULOMB_LOG = 20.;         // Coulomb logarithm
+constexpr Real ALPHAFS = 0.007299270073;  // Fine structure constant ~ 1./137.
+constexpr Real GFERM = 1.435850814e-49;   // Fermi constant
+constexpr Real GA = -1.272323;            // Axial-vector coupling
+constexpr Real GA2 = GA * GA;
+constexpr Real S2THW = 0.222321; // sin^2(Theta_W), Theta_W = Weinberg angle
+constexpr Real S4THW = S2THW * S2THW;
+constexpr Real NUSIGMA0 =
+    1.7611737037e-44; // Fundamental neutrino cross section
+
+// Unit conversions
+constexpr Real EV = 1.60217653e-12;   // Electron-volt
+constexpr Real MEV = 1.0e6 * EV;      // Mega-Electron-Volt
+constexpr Real GEV = 1.0e9 * EV;      // Giga-Electron-Volt
+constexpr Real JY = 1.e-23;           // Jansky
+constexpr Real PC = 3.085678e18;      // Parsec
+constexpr Real AU = 1.49597870691e13; // Astronomical unit
+constexpr Real YEAR = 31536000.;
+constexpr Real DAY = 86400.;
+constexpr Real HOUR = 3600.;
+constexpr Real MSUN = 1.989e33; // Solar mass
+constexpr Real RSUN = 6.96e10;  // Solar radius
+constexpr Real LSUN = 3.827e33; // Solar luminosity
+
+} // namespace cgs
+} // namespace constants
+} // namespace singularity
+
+#endif // UTILS_OPAC_UTILS_PHYSICAL_CONSTANTS

--- a/utils/opac-utils/radiation_types.hpp
+++ b/utils/opac-utils/radiation_types.hpp
@@ -13,14 +13,39 @@
 // publicly, and to permit others to do so.
 // ======================================================================
 
-#ifndef OPACITIES_OPAC_
-#define OPACITIES_OPAC_
+#ifndef UTILS_OPAC_UTILS_RADIATION_TYPES
+#define UTILS_OPAC_UTILS_RADIATION_TYPES
 
+#include "opac_error.hpp"
 
 namespace singularity {
 
+enum class RadiationType {
+  TRACER = -1,
+  NU_ELECTRON = 0,
+  NU_ELECTRON_ANTI = 1,
+  NU_HEAVY = 2,
+  PHOTON = 3
+};
 
+int RadType2Idx(RadiationType type) { return static_cast<int>(type); }
+RadiationType Idx2RadType(int i) {
+  switch (i) {
+  case -1:
+    return RadiationType::Tracer;
+  case 0:
+    return RadiationType::Nu_Electron;
+  case 1:
+    return RadiationType::NU_ELECTRON_ANTI;
+  case 2:
+    return RadiationType::NU_HEAVY;
+  case 3:
+    return RadiationType::PHOTON;
+  default:
+    OPAC_ERROR("Unknown radiation type");
+  }
+}
 
 } // namespace singularity
 
-#endif // OPACITIES_OPAC_
+#endif // UTILS_OPAC_UTILS_RADIATION_TYPES


### PR DESCRIPTION
This is a first pass at analytic opacities. I'm not done, and I also haven't fully tested the machinery. But I wanted to get thoughts on what I have so far. In particular, I wanted your opinion on the function signatures, the structure of the variant, and the emphasis on header-only calls.

Note the function signatures don't expose Ye but they do expose radiation type. My reasoning for allowing this is that in principle one could run, e.g., neutrinos and photons at the same time, or some other kind of radiation. I'm not necessarily attached to this. The radiation type could be moved into the lambda and hidden, though it would be a little gross.