### PR TITLE
Add include guards and fix cmake_dependent_option

### DIFF
--- a/cmake/SetupDeps.cmake
+++ b/cmake/SetupDeps.cmake
@@ -3,19 +3,29 @@ include(FeatureSummary)
 # Setup CUDAToolkit
 # - provideds CUDA::toolkit
 #=======================================
-find_package(CUDAToolkit QUIET)
+if (NOT TARGET CUDA::toolkit)
+  find_package(CUDAToolkit QUIET)
+else()
+  message(status "CUDA::toolkit provided by parent package")
+endif()
 
 #=======================================
 # Setup Kokkos
 # - provides Kokkos::kokkos
 #=======================================
-find_package(Kokkos QUIET)
+if (NOT TARGET Kokkos::kokkos)
+  find_package(Kokkos QUIET)
+else()
+  message(status "Kokkos::kokkos provided by parent package")
+endif()
 
 #=======================================
 # Find HDF5
 # - cmake@3.20+ provides HDF5::HDF5, but
 #   prior versions do not
 #=======================================
+# Can't play the target games above unless using
+# cmake 3.20+, so leave this one for now.
 find_package(HDF5 COMPONENTS C HL QUIET)
 
 # findpackage doesnt export an interface for HDF5,
@@ -31,7 +41,21 @@ if (HDF5_FOUND)
 
     # if HDF5 is parallel, also get MPI libraries
     if (HDF5_IS_PARALELL)
-        find_package(MPI COMPONENTS CXX REQUIRED)
+      message(status "Parallel HDF5 found. Looking for MPI")
+      # Provides MPI::MPI_CXX
+      if (NOT TARGET MPI::MPI_CXX)
+	find_package(MPI COMPONENTS CXX REQUIRED)
+	if (NOT MPI_FOUND)
+	  message(FATAL_ERROR
+	    "HDF5 parallel found, but could not find MPI! "
+	    "Try specifying a path to an MPI directory or MPI compiler "
+	    " via -DMPI_HOME=/path or -DMPI_CXX_COMPILER=/path, "
+	    "or set CMAKE_PREFIX_PATH to your preferred HDF5 directory "
+	    "via -DCMAKE_PREFIX_PATH=/path.")
+	endif()
+      else()
+	message("MPI::MPI_CXX provided by parent package")
+      endif()
     endif()
 endif()
 
@@ -39,7 +63,6 @@ endif()
 # Setup Catch2
 # - provides Catch2::Catch2
 #=======================================
-find_package(Catch2 QUIET)
-
-
-
+if (NOT TARGET Catch2::Catch2)
+  find_package(Catch2 QUIET)
+endif()

--- a/cmake/SetupOptions.cmake
+++ b/cmake/SetupOptions.cmake
@@ -23,18 +23,21 @@ option (SINGULARITY_USE_KOKKOS "Use Kokkos for portability" OFF)
 option (SINGULARITY_USE_CUDA "Enable cuda support" OFF)
 option (SINGULARITY_USE_HDF5 "Pull in hdf5" OFF)
 
-cmake_dependent_option(SINGULARITY_USE_MPI "Link to MPI" OFF "HDF5_IS_PARALLEL" ON)
+# If the conditional is TRUE, it's the first default, else it's the
+# second.
+cmake_dependent_option(SINGULARITY_USE_MPI "Link to MPI"
+  ON "${SINGULARITY_USE_MPI};${HDF5_IS_PARALLEL}" OFF)
 
 #=======================================
 # Options logic
 #=======================================
 # check for currently incompatible option
 if(SINGULARITY_USE_CUDA)
-  if(NOT CUDAToolkit_FOUND)
+  if(NOT TARGET CUDA::toolkit)
     message(FATAL_ERROR "Requested build with CUDA, but could not find in the environment.")
   endif()
   if(SINGULARITY_USE_KOKKOS)
-    if(NOT Kokkos_FOUND)
+    if(NOT TARGET Kokkos::kokkos)
       message(WARNING "Requested build with Kokkos, but could not find in the environment.")
       message(STATUS  "Configuring internal Kokkos submodule.")
       set(NVCC_WRAPPER_BIN ${CMAKE_CURRENT_SOURCE_DIR}/utils/kokkos/bin/nvcc_wrapper CACHE STRING "")


### PR DESCRIPTION
Several cmake tweaks:
- Include guards so that when `singularity-opac` is built downstream, it only calls `FindPackage` if the needed targets are not already provided by a parent package. This is needed to keep package consistency for in-tree builds, so all subpackages use the same libraries. Thanks to @brryan for finding this issue.
- Added a bit more verbose messaging for these target checks
- Fixed an inverted argument list in `cmake_dependent_option` to prevent `cmake` from trying to link MPI when MPI is not found.
