### PR TITLE
Add singularity-opac::flags cmake target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,11 @@ add_library(${PROJECT_NAME} INTERFACE IMPORTED GLOBAL)
 # so we can use with add_subdirectory
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
+add_library (singularity-opac::flags INTERFACE IMPORTED GLOBAL)
+target_include_directories(singularity-opac::flags
+                           INTERFACE
+                           $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>)
+
 include (SetupDeps)
 include (SetupOptions)
 include (SetupCompilers)
@@ -73,6 +78,22 @@ execute_process(COMMAND patch -N -s -V never
                 ${CMAKE_CURRENT_SOURCE_DIR}/utils/variant/include/mpark/variant.hpp
                 ${CMAKE_CURRENT_SOURCE_DIR}/utils/cuda_compatibility.patch)
 
+# xl fix
+target_compile_options(singularity-opac::flags INTERFACE
+                       $<$<COMPILE_LANG_AND_ID:CXX,XL>:-std=c++1y;-qxflag=disable__cplusplusOverride>)
+target_link_options(singularity-opac::flags INTERFACE
+                    $<$<COMPILE_LANG_AND_ID:CXX,XL>:-std=c++1y;-qxflag=disable__cplusplusOverride>)
+
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+  target_compile_options(singularity-opac::flags INTERFACE
+                         -use_fast_math)
+elseif(CMAKE_BUILD_TYPE STREQUAL "Debug" AND SINGULARITY_BETTER_DEBUG_FLAGS)
+  target_compile_options(
+    singularity-opac::flags
+    INTERFACE
+    "$<$<COMPILE_LANGUAGE:CXX>:-G;-lineinfo;>"
+    )
+endif()
 
 # Invoke CMake scripts for setup
 if(SINGULARITY_INSTALL_LIBRARY)

--- a/cmake/FindPortsofCall.cmake
+++ b/cmake/FindPortsofCall.cmake
@@ -1,0 +1,29 @@
+#------------------------------------------------------------------------------#
+# © 2021. Triad National Security, LLC. All rights reserved.  This
+# program was produced under U.S. Government contract 89233218CNA000001
+# for Los Alamos National Laboratory (LANL), which is operated by Triad
+# National Security, LLC for the U.S.  Department of Energy/National
+# Nuclear Security Administration. All rights in the program are
+# reserved by Triad National Security, LLC, and the U.S. Department of
+# Energy/National Nuclear Security Administration. The Government is
+# granted for itself and others acting on its behalf a nonexclusive,
+# paid-up, irrevocable worldwide license in this material to reproduce,
+# prepare derivative works, distribute copies to the public, perform
+# publicly and display publicly, and to permit others to do so.
+#------------------------------------------------------------------------------#
+
+# Ports of Call
+SET(PortsofCall_INCLUDE_DIR "${PROJECT_SOURCE_DIR}/utils/ports-of-call")
+
+# handle the QUIETLY and REQUIRED arguments and set EOSPAC_FOUND to TRUE if
+# all listed variables are TRUE
+INCLUDE(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(PortsofCall DEFAULT_MSG
+                                  )#PortsofCall_INCLUDE_DIR)
+
+# Copy the results to the output variables.
+SET(PortsofCall_INCLUDE_DIRS ${PortsofCall_INCLUDE_DIR})
+
+add_library(PortsofCall::PortsofCall INTERFACE IMPORTED)
+set_target_properties(PortsofCall::PortsofCall PROPERTIES
+		      INTERFACE_INCLUDE_DIRECTORIES "${PortsofCall_INCLUDE_DIR}")

--- a/cmake/SetupDeps.cmake
+++ b/cmake/SetupDeps.cmake
@@ -10,6 +10,13 @@ else()
 endif()
 
 #=======================================
+# Setup ports of call
+# - provides PortsofCall::PortsofCall
+#=======================================
+find_package(PortsofCall REQUIRED)
+target_link_libraries(singularity-opac::flags INTERFACE PortsofCall::PortsofCall)
+
+#=======================================
 # Setup Kokkos
 # - provides Kokkos::kokkos
 #=======================================
@@ -31,6 +38,7 @@ find_package(HDF5 COMPONENTS C HL QUIET)
 # findpackage doesnt export an interface for HDF5,
 # so create one
 if (HDF5_FOUND)
+    target_compile_definitions(singularity-opac::flags INTERFACE SPINER_USE_HDF)
     add_library(${PROJECT_NAME}::hdf5 INTERFACE IMPORTED)
     set_target_properties(${PROJECT_NAME}::hdf5
     PROPERTIES

--- a/singularity-opac/neutrinos/opac_neutrinos.hpp
+++ b/singularity-opac/neutrinos/opac_neutrinos.hpp
@@ -16,7 +16,7 @@
 #ifndef SINGULARITY_OPAC_NEUTRINOS_OPAC_NEUTRINOS_
 #define SINGULARITY_OPAC_NEUTRINOS_OPAC_NEUTRINOS_
 
-#include <variant/include/mpark/variant.hpp>
+#include "../../utils/variant/include/mpark/variant.hpp"
 
 #include <singularity-opac/neutrinos/gray_opacity_neutrinos.hpp>
 #include <singularity-opac/neutrinos/neutrino_variant.hpp>

--- a/singularity-opac/neutrinos/opac_neutrinos.hpp
+++ b/singularity-opac/neutrinos/opac_neutrinos.hpp
@@ -16,7 +16,7 @@
 #ifndef SINGULARITY_OPAC_NEUTRINOS_OPAC_NEUTRINOS_
 #define SINGULARITY_OPAC_NEUTRINOS_OPAC_NEUTRINOS_
 
-#include "../../utils/variant/include/mpark/variant.hpp"
+#include <variant/include/mpark/variant.hpp>
 
 #include <singularity-opac/neutrinos/gray_opacity_neutrinos.hpp>
 #include <singularity-opac/neutrinos/neutrino_variant.hpp>


### PR DESCRIPTION
To avoid relative include paths for headers in dependencies like ports-of-call, we want to add a `singularity-opac::flags` cmake target like how `singularity-eos` already works. This PR adds that feature. Not all the details in the `singularity-eos` implementation are included here (e.g. 
```cmake
    if(SINGULARITY_HIDE_MORE_WARNINGS)                                                               
      target_compile_options(                                                                        
        singularity-eos::flags                                                                       
         INTERFACE # Generator expression shamelessly copied from EAP                                
         "$<$<COMPILE_LANGUAGE:CXX>:--expt-relaxed-constexpr;>"                                      
           )                                                                                         
    else()                                                                                           
      target_compile_options(                                                                        
        singularity-eos::flags                                                                       
         INTERFACE # Generator expression shamelessly copied from EAP                                
         "$<$<COMPILE_LANGUAGE:CXX>:--expt-relaxed-constexpr;-Xcudafe;--diag_suppress=esa_on_defaulted_function_ignored;>"
           )                                                                                         
    endif()
```
because I'm quickly getting out of my depth, but I think this is a good starting point.