### PR TITLE
Add inline to fix multiple definitions errors

### DIFF
--- a/singularity-opac/base/radiation_types.hpp
+++ b/singularity-opac/base/radiation_types.hpp
@@ -28,8 +28,9 @@ enum class RadiationType {
   PHOTON = 3
 };
 
-int RadType2Idx(RadiationType type) { return static_cast<int>(type); }
-RadiationType Idx2RadType(int i) {
+inline int RadType2Idx(RadiationType type) { return static_cast<int>(type); }
+
+inline RadiationType Idx2RadType(int i) {
   switch (i) {
   case -1:
     return RadiationType::TRACER;


### PR DESCRIPTION
in `singularity-opac/base/radiation_types.hpp` there are two functions `int RadType2Idx(RadiationType type)` and `RadiationType Idx2RadType(int i)` which (I think generally, but definitely for my use case) give multiple definition errors when compiling/linking code that uses `singularity-opac` in multiple places. I here add `inline` qualifiers to these functions to fix that issue.