### PR TITLE
Switch from constexpr to preproc for EPS for C++14 compatibility

### DIFF
--- a/singularity-opac/neutrinos/thermal_distributions_neutrinos.hpp
+++ b/singularity-opac/neutrinos/thermal_distributions_neutrinos.hpp
@@ -27,9 +27,10 @@ namespace neutrinos {
 
 using pc = PhysicalConstants<CGS>;
 
+#define EPS (10.0 * std::numeric_limits<Real>::epsilon())
+
 template <int NSPECIES>
 struct FermiDiracDistributionNoMu {
-  static constexpr Real EPS = 10.0 * std::numeric_limits<Real>::epsilon();
   PORTABLE_INLINE_FUNCTION
   Real ThermalDistributionOfTNu(const Real temp, const RadiationType type,
                                 const Real nu, Real *lambda = nullptr) const {
@@ -60,6 +61,8 @@ struct FermiDiracDistributionNoMu {
     return jnu / Bnu;
   }
 };
+
+#undef EPS
 
 } // namespace neutrinos
 } // namespace singularity


### PR DESCRIPTION
Downstream I'm compiling with C++14 which doesn't have inline variables. I was getting linking errors with the `constexpr` implementation of `EPS` as seen in the changes. This changeset works with my code and I claim it is relatively safe because `EPS` is `#undef`'d. If there's another way to get the `constexpr` approach to work in a header-only framework I'd be happy to do that instead though. 