### PR TITLE
Remove extraneous 4pi

### DIFF
--- a/singularity-opac/neutrinos/tophat_emissivity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/tophat_emissivity_neutrinos.hpp
@@ -93,7 +93,7 @@ class TophatEmissivity {
                             const RadiationType type, const Real nu,
                             Real *lambda = nullptr) const {
     if (nu > numin_ && nu < numax_) {
-      return C_ * GetYeF(type, Ye) / (4. * M_PI);
+      return C_ * GetYeF(type, Ye);
     } else {
       return 0.;
     }


### PR DESCRIPTION
There was an extra `4*M_PI` in the denominator of the tophat `EmissivityPerNuOmega` -- note that the angle-integrated emissivities in the same file are *multiplied* by `4.*M_PI`