### PR TITLE
Fix integrated distribution functions

### DIFF
--- a/singularity-opac/neutrinos/thermal_distributions_neutrinos.hpp
+++ b/singularity-opac/neutrinos/thermal_distributions_neutrinos.hpp
@@ -43,14 +43,14 @@ struct FermiDiracDistributionNoMu {
   Real ThermalDistributionOfT(const Real temp, const RadiationType type,
                               Real *lambda = nullptr) const {
     return 7. * std::pow(M_PI, 5) * std::pow(pc::kb, 4) * NSPECIES *
-           std::pow(temp, 4) / (15. * std::pow(pc::c, 2) * std::pow(pc::h, 3));
+           std::pow(temp, 4) / (15. * std::pow(pc::c, 3) * std::pow(pc::h, 3));
   }
   PORTABLE_INLINE_FUNCTION
   Real ThermalNumberDistribution(const Real temp, const RadiationType type,
                                  Real *lambda = nullptr) const {
     constexpr Real zeta3 = 1.20206;
-    return 12. * pow(pc::kb, 3) * M_PI * NSPECIES * pow(temp, 3) * zeta3 /
-           (pow(pc::c, 2) * pow(pc::h, 3));
+    return 16. * pow(pc::kb, 3) * M_PI * NSPECIES * pow(temp, 3) * zeta3 /
+           (pow(pc::c, 3) * pow(pc::h, 3));
   }
   template <typename Emissivity>
   PORTABLE_INLINE_FUNCTION Real AbsorptionCoefficientFromKirkhoff(

--- a/singularity-opac/photons/thermal_distributions_photons.hpp
+++ b/singularity-opac/photons/thermal_distributions_photons.hpp
@@ -39,14 +39,14 @@ struct PlanckDistribution {
   PORTABLE_INLINE_FUNCTION
   Real ThermalDistributionOfT(const Real temp, Real *lambda = nullptr) const {
     return 8. * std::pow(M_PI, 5) * std::pow(pc::kb, 4) * std::pow(temp, 4) /
-           (15. * std::pow(pc::c, 2) * std::pow(pc::h, 3));
+           (15. * std::pow(pc::c, 3) * std::pow(pc::h, 3));
   }
   PORTABLE_INLINE_FUNCTION
   Real ThermalNumberDistribution(const Real temp,
                                  Real *lambda = nullptr) const {
     constexpr Real zeta3 = 1.20206;
     return 16. * pow(pc::kb, 3) * M_PI * pow(temp, 3) * zeta3 /
-           (pow(pc::c, 2) * pow(pc::h, 3));
+           (pow(pc::c, 3) * pow(pc::h, 3));
   }
   template <typename Emissivity>
   PORTABLE_INLINE_FUNCTION Real AbsorptionCoefficientFromKirkhoff(


### PR DESCRIPTION
There was a missing 1/c factor in the integrated distribution functions for photons and neutrinos. The specific intensity `B_nu = dE / (dA dt dOmega dnu)`, so e.g. the energy density `u = dE / dV = 4 pi / c \int B_nu dnu`. This is consistent with `u = a_R T^4` for photons.

Also, I get a 16 instead of a 12 as the prefactor for the neutrino thermal number density, maybe I forgot some neutrino physics. Anyway here's my mathematica output:

<img width="430" alt="image" src="https://user-images.githubusercontent.com/2207688/157296931-80137af0-dfdf-45f1-bae2-28d667f0daf9.png">

<img width="380" alt="image" src="https://user-images.githubusercontent.com/2207688/157297008-f7051686-05a8-414a-8bd7-fea68f5f73ae.png">
