### PR TITLE
Add thermal distributions to interface

### DIFF
--- a/singularity-opac/neutrinos/gray_opacity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/gray_opacity_neutrinos.hpp
@@ -134,16 +134,20 @@ class GrayOpacity {
 
   PORTABLE_INLINE_FUNCTION
   Real ThermalDistributionOfTNu(const Real temp, const RadiationType type,
-    const Real nu, Real *lambda = nullptr) const {
-      return dist_.ThermalDistributionOfTNu(temp, type, nu, lambda);
-    }
+                                const Real nu, Real *lambda = nullptr) const {
+    return dist_.ThermalDistributionOfTNu(temp, type, nu, lambda);
+  }
 
   PORTABLE_INLINE_FUNCTION
   Real ThermalDistributionOfT(const Real temp, const RadiationType type,
-    Real *lambda = nullptr) const {
-      return dist_.ThermalDistributionOfT(temp, type, lambda);
-    }
+                              Real *lambda = nullptr) const {
+    return dist_.ThermalDistributionOfT(temp, type, lambda);
+  }
 
+  PORTABLE_INLINE_FUNCTION Real ThermalNumberDistribution(
+      const Real temp, const RadiationType type, Real *lambda = nullptr) const {
+    return dist_.ThermalNumberDistribution(temp, type, lambda);
+  }
 
  private:
   Real kappa_; // Opacity. Units of cm^2/g

--- a/singularity-opac/neutrinos/gray_opacity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/gray_opacity_neutrinos.hpp
@@ -132,6 +132,19 @@ class GrayOpacity {
            dist_.ThermalNumberDistribution(temp, type, lambda);
   }
 
+  PORTABLE_INLINE_FUNCTION
+  Real ThermalDistributionOfTNu(const Real temp, const RadiationType type,
+    const Real nu, Real *lambda = nullptr) const {
+      return dist_.ThermalDistributionOfTNu(temp, type, nu, lambda);
+    }
+
+  PORTABLE_INLINE_FUNCTION
+  Real ThermalDistributionOfT(const Real temp, const RadiationType type,
+    Real *lambda = nullptr) const {
+      return dist_.ThermalDistributionOfT(temp, type, lambda);
+    }
+
+
  private:
   Real kappa_; // Opacity. Units of cm^2/g
   ThermalDistribution dist_;

--- a/singularity-opac/neutrinos/neutrino_variant.hpp
+++ b/singularity-opac/neutrinos/neutrino_variant.hpp
@@ -204,34 +204,35 @@ class Variant {
   }
 
   // Specific intensity of thermal distribution
-  PORTABLE_INLINE_FUNCTION Real ThermalDistributionOfTNu(const Real temp, const RadiationType type,
-   const Real nu, Real *lambda = nullptr) const {
-     return mpark::visit(
-       [=](const auto &opac) {
-         return opac.ThermalDistributionOfTNu(temp, type, nu, lambda);
-       },
-       opac_);
-   }
+  PORTABLE_INLINE_FUNCTION Real
+  ThermalDistributionOfTNu(const Real temp, const RadiationType type,
+                           const Real nu, Real *lambda = nullptr) const {
+    return mpark::visit(
+        [=](const auto &opac) {
+          return opac.ThermalDistributionOfTNu(temp, type, nu, lambda);
+        },
+        opac_);
+  }
 
   // Energy density of thermal distribution
-  PORTABLE_INLINE_FUNCTION Real ThermalDistributionOfT(const Real temp, const RadiationType type,
-   Real *lambda = nullptr) const {
-     return mpark::visit(
-       [=](const auto &opac) {
-         return opac.ThermalDistributionOfT(temp, type, lambda);
-       },
-       opac_);
-   }
+  PORTABLE_INLINE_FUNCTION Real ThermalDistributionOfT(
+      const Real temp, const RadiationType type, Real *lambda = nullptr) const {
+    return mpark::visit(
+        [=](const auto &opac) {
+          return opac.ThermalDistributionOfT(temp, type, lambda);
+        },
+        opac_);
+  }
 
   // Number density of thermal distribution
-  PORTABLE_INLINE_FUNCTION Real ThermalNumberDistribution(const Real temp, const RadiationType type,
-   Real *lambda = nullptr) const {
-     return mpark::visit(
-       [=](const auto &opac) {
-         return opac.ThermalNumberDistribution(temp, type, lambda);
-       },
-       opac_);
-   }
+  PORTABLE_INLINE_FUNCTION Real ThermalNumberDistribution(
+      const Real temp, const RadiationType type, Real *lambda = nullptr) const {
+    return mpark::visit(
+        [=](const auto &opac) {
+          return opac.ThermalNumberDistribution(temp, type, lambda);
+        },
+        opac_);
+  }
 
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept {

--- a/singularity-opac/neutrinos/neutrino_variant.hpp
+++ b/singularity-opac/neutrinos/neutrino_variant.hpp
@@ -223,6 +223,16 @@ class Variant {
        opac_);
    }
 
+  // Number density of thermal distribution
+  PORTABLE_INLINE_FUNCTION Real ThermalNumberDistribution(const Real temp, const RadiationType type,
+   Real *lambda = nullptr) const {
+     return mpark::visit(
+       [=](const auto &opac) {
+         return opac.ThermalNumberDistribution(temp, type, lambda);
+       },
+       opac_);
+   }
+
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept {
     return mpark::visit([](const auto &opac) { return opac.nlambda(); }, opac_);

--- a/singularity-opac/neutrinos/neutrino_variant.hpp
+++ b/singularity-opac/neutrinos/neutrino_variant.hpp
@@ -203,6 +203,26 @@ class Variant {
         opac_);
   }
 
+  // Specific intensity of thermal distribution
+  PORTABLE_INLINE_FUNCTION Real ThermalDistributionOfTNu(const Real temp, const RadiationType type,
+   const Real nu, Real *lambda = nullptr) const {
+     return mpark::visit(
+       [=](const auto &opac) {
+         return opac.ThermalDistributionOfTNu(temp, type, nu, lambda);
+       },
+       opac_);
+   }
+
+  // Energy density of thermal distribution
+  PORTABLE_INLINE_FUNCTION Real ThermalDistributionOfT(const Real temp, const RadiationType type,
+   Real *lambda = nullptr) const {
+     return mpark::visit(
+       [=](const auto &opac) {
+         return opac.ThermalDistributionOfT(temp, type, lambda);
+       },
+       opac_);
+   }
+
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept {
     return mpark::visit([](const auto &opac) { return opac.nlambda(); }, opac_);

--- a/singularity-opac/neutrinos/non_cgs_neutrinos.hpp
+++ b/singularity-opac/neutrinos/non_cgs_neutrinos.hpp
@@ -194,6 +194,13 @@ class NonCGSUnits {
     return BoH * inv_energy_dens_unit_;
   }
 
+  PORTABLE_INLINE_FUNCTION
+  Real ThermalNumberDistribution(const Real temp, const RadiationType type,
+                                 Real *lambda = nullptr) const {
+    Real NoH = opac_.ThermalNumberDistribution(temp, type, lambda);
+    return NoH * mass_unit_ / rho_unit_;
+  }
+
  private:
   Opac opac_;
   Real time_unit_, mass_unit_, length_unit_, temp_unit_;

--- a/singularity-opac/neutrinos/non_cgs_neutrinos.hpp
+++ b/singularity-opac/neutrinos/non_cgs_neutrinos.hpp
@@ -38,7 +38,10 @@ class NonCGSUnits {
         freq_unit_(1. / time_unit_),
         inv_emiss_unit_(length_unit_ * time_unit_ * time_unit_ / mass_unit_),
         inv_num_emiss_unit_(length_unit_ * length_unit_ * length_unit_ *
-                            time_unit_) {}
+                            time_unit_),
+        inv_intensity_unit_(time_unit_ * time_unit_ / mass_unit_),
+        inv_energy_dens_unit_(time_unit_ * time_unit_ * length_unit_ /
+                              mass_unit_) {}
 
   auto GetOnDevice() {
     return NonCGSUnits<Opac>(opac_.GetOnDevice(), time_unit_, mass_unit_,
@@ -177,10 +180,25 @@ class NonCGSUnits {
     return JoH * inv_num_emiss_unit_;
   }
 
+  PORTABLE_INLINE_FUNCTION
+  Real ThermalDistributionOfTNu(const Real temp, const RadiationType type,
+                                const Real nu, Real *lambda = nullptr) const {
+    Real BoH = opac_.ThermalDistributionOfTNu(temp, type, nu, lambda);
+    return BoH * inv_intensity_unit_;
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real ThermalDistributionOfT(const Real temp, const RadiationType type,
+                              Real *lambda = nullptr) const {
+    Real BoH = opac_.ThermalDistributionOfT(temp, type, lambda);
+    return BoH * inv_energy_dens_unit_;
+  }
+
  private:
   Opac opac_;
   Real time_unit_, mass_unit_, length_unit_, temp_unit_;
   Real rho_unit_, freq_unit_, inv_emiss_unit_, inv_num_emiss_unit_;
+  Real inv_intensity_unit_, inv_energy_dens_unit_;
 };
 
 } // namespace neutrinos

--- a/singularity-opac/neutrinos/opac_neutrinos.hpp
+++ b/singularity-opac/neutrinos/opac_neutrinos.hpp
@@ -31,9 +31,10 @@ namespace neutrinos {
 // TODO(JMM): Include chemical potential
 using Gray = GrayOpacity<FermiDiracDistributionNoMu<3>>;
 using Tophat = TophatEmissivity<FermiDiracDistributionNoMu<3>>;
+using SpinerOpac = SpinerOpacity<FermiDiracDistributionNoMu<3>>;
 
-using Opacity = impl::Variant<Gray, Tophat, SpinerOpacity, NonCGSUnits<Gray>,
-                              NonCGSUnits<Tophat>, NonCGSUnits<SpinerOpacity>>;
+using Opacity = impl::Variant<Gray, Tophat, SpinerOpac, NonCGSUnits<Gray>,
+                              NonCGSUnits<Tophat>, NonCGSUnits<SpinerOpac>>;
 
 } // namespace neutrinos
 } // namespace singularity

--- a/singularity-opac/neutrinos/spiner_opac_neutrinos.hpp
+++ b/singularity-opac/neutrinos/spiner_opac_neutrinos.hpp
@@ -64,6 +64,7 @@ enum class DataStatus { Deallocated, OnDevice, OnHost };
 // DataBox. Bottom of the table is a floor. Top of the table is
 // power law extrapolation.
 // TODO(JMM): Should lJ be stored on disk or computed at start up?
+template <typename ThermalDistribution>
 class SpinerOpacity {
  public:
   static constexpr Real EPS = 10.0 * std::numeric_limits<Real>::epsilon();
@@ -319,6 +320,18 @@ class SpinerOpacity {
     return fromLog_(lJYe_.interpToReal(lRho, lT, Ye, idx));
   }
 
+  PORTABLE_INLINE_FUNCTION
+  Real ThermalDistributionOfTNu(const Real temp, const RadiationType type,
+    const Real nu, Real *lambda = nullptr) const {
+      return dist_.ThermalDistributionOfTNu(temp, type, nu, lambda);
+    }
+
+  PORTABLE_INLINE_FUNCTION
+  Real ThermalDistributionOfT(const Real temp, const RadiationType type,
+    Real *lambda = nullptr) const {
+      return dist_.ThermalDistributionOfT(temp, type, lambda);
+    }
+
 private:
   // TODO(JMM): Offsets probably not necessary
   PORTABLE_INLINE_FUNCTION Real toLog_(const Real x, const Real offset) const {
@@ -349,6 +362,7 @@ private:
   // TODO(JMM): Should we add table bounds? Given they're recorded in
   // each spiner table, I lean towards no, but could be convinced
   // otherwise if we need to do extrapolation, etc.
+  ThermalDistribution dist_;
 };
 
 } // namespace neutrinos

--- a/singularity-opac/neutrinos/spiner_opac_neutrinos.hpp
+++ b/singularity-opac/neutrinos/spiner_opac_neutrinos.hpp
@@ -108,7 +108,7 @@ class SpinerOpacity {
           for (int idx = 0; idx < NEUTRINO_NTYPES; ++idx) {
             RadiationType type = Idx2RadType(idx);
             Real J = std::max(opac.Emissivity(rho, T, Ye, type), 0.0);
-	    Real lJ = toLog_(J);
+            Real lJ = toLog_(J);
             lJ_(iRho, iT, iYe, idx) = lJ;
             Real JYe = std::max(opac.NumberEmissivity(rho, T, Ye, type), 0.0);
             lJYe_(iRho, iT, iYe, idx) = toLog_(JYe);
@@ -192,9 +192,9 @@ class SpinerOpacity {
   }
 
   PORTABLE_INLINE_FUNCTION
-  Real AbsorptionCoefficient(const Real rho, const Real temp,
-                                  const Real Ye, const RadiationType type,
-                                  const Real nu, Real *lambda = nullptr) const {
+  Real AbsorptionCoefficient(const Real rho, const Real temp, const Real Ye,
+                             const RadiationType type, const Real nu,
+                             Real *lambda = nullptr) const {
     int idx;
     Real lRho, lT;
     toLogs_(rho, temp, type, lRho, lT, idx);
@@ -207,10 +207,11 @@ class SpinerOpacity {
   // TODO(JMM): Should we provide a raw copy operator instead of or
   // addition to interpolation?
   template <typename FrequencyIndexer, typename DataIndexer>
-  PORTABLE_INLINE_FUNCTION void AbsorptionCoefficient(
-      const Real rho, const Real temp, const Real Ye, const RadiationType type,
-      FrequencyIndexer &nu_bins, DataIndexer &coeffs, const int nbins,
-      Real *lambda = nullptr) const {
+  PORTABLE_INLINE_FUNCTION void
+  AbsorptionCoefficient(const Real rho, const Real temp, const Real Ye,
+                        const RadiationType type, FrequencyIndexer &nu_bins,
+                        DataIndexer &coeffs, const int nbins,
+                        Real *lambda = nullptr) const {
     int idx;
     Real lRho, lT;
     toLogs_(rho, temp, type, lRho, lT, idx);
@@ -220,11 +221,14 @@ class SpinerOpacity {
     }
   }
 
-  // Angle-averaged absorption coefficient assumed to be the same as absorption coefficient
+  // Angle-averaged absorption coefficient assumed to be the same as absorption
+  // coefficient
   PORTABLE_INLINE_FUNCTION
   Real AngleAveragedAbsorptionCoefficient(const Real rho, const Real temp,
-                                  const Real Ye, const RadiationType type,
-                                  const Real nu, Real *lambda = nullptr) const {
+                                          const Real Ye,
+                                          const RadiationType type,
+                                          const Real nu,
+                                          Real *lambda = nullptr) const {
     int idx;
     Real lRho, lT;
     toLogs_(rho, temp, type, lRho, lT, idx);
@@ -265,9 +269,9 @@ class SpinerOpacity {
   template <typename FrequencyIndexer, typename DataIndexer>
   PORTABLE_INLINE_FUNCTION void
   EmissivityPerNuOmega(const Real rho, const Real temp, const Real Ye,
-                       const RadiationType type,
-                       FrequencyIndexer &nu_bins, DataIndexer &coeffs,
-                       const int nbins, Real *lambda = nullptr) const {
+                       const RadiationType type, FrequencyIndexer &nu_bins,
+                       DataIndexer &coeffs, const int nbins,
+                       Real *lambda = nullptr) const {
     int idx;
     Real lRho, lT;
     toLogs_(rho, temp, type, lRho, lT, idx);
@@ -322,17 +326,22 @@ class SpinerOpacity {
 
   PORTABLE_INLINE_FUNCTION
   Real ThermalDistributionOfTNu(const Real temp, const RadiationType type,
-    const Real nu, Real *lambda = nullptr) const {
-      return dist_.ThermalDistributionOfTNu(temp, type, nu, lambda);
-    }
+                                const Real nu, Real *lambda = nullptr) const {
+    return dist_.ThermalDistributionOfTNu(temp, type, nu, lambda);
+  }
 
   PORTABLE_INLINE_FUNCTION
   Real ThermalDistributionOfT(const Real temp, const RadiationType type,
-    Real *lambda = nullptr) const {
-      return dist_.ThermalDistributionOfT(temp, type, lambda);
-    }
+                              Real *lambda = nullptr) const {
+    return dist_.ThermalDistributionOfT(temp, type, lambda);
+  }
 
-private:
+  PORTABLE_INLINE_FUNCTION Real ThermalNumberDistribution(
+      const Real temp, const RadiationType type, Real *lambda = nullptr) const {
+    return dist_.ThermalNumberDistribution(temp, type, lambda);
+  }
+
+ private:
   // TODO(JMM): Offsets probably not necessary
   PORTABLE_INLINE_FUNCTION Real toLog_(const Real x, const Real offset) const {
     return std::log10(std::abs(std::max(x, -offset) + offset) + EPS);

--- a/singularity-opac/neutrinos/thermal_distributions_neutrinos.hpp
+++ b/singularity-opac/neutrinos/thermal_distributions_neutrinos.hpp
@@ -56,16 +56,21 @@ struct FermiDiracDistributionNoMu {
   PORTABLE_INLINE_FUNCTION Real AbsorptionCoefficientFromKirkhoff(
       const Emissivity &J, const Real rho, const Real temp, const Real Ye,
       const RadiationType type, const Real nu, Real *lambda = nullptr) const {
-    const Real Bnu = std::max(ThermalDistributionOfTNu(temp, type, nu, lambda), EPS);
-    const Real jnu = std::max(J.EmissivityPerNuOmega(rho, temp, Ye, type, nu, lambda), EPS);
+    const Real Bnu =
+        std::max(ThermalDistributionOfTNu(temp, type, nu, lambda), EPS);
+    const Real jnu =
+        std::max(J.EmissivityPerNuOmega(rho, temp, Ye, type, nu, lambda), EPS);
     return jnu / Bnu;
   }
   template <typename Emissivity>
   PORTABLE_INLINE_FUNCTION Real AngleAveragedAbsorptionCoefficientFromKirkhoff(
       const Emissivity &J, const Real rho, const Real temp, const Real Ye,
       const RadiationType type, const Real nu, Real *lambda = nullptr) const {
-    const Real Bnu = std::max(ThermalDistributionOfTNu(temp, type, nu, lambda), EPS);
-    const Real jnu = std::max(J.EmissivityPerNu(rho, temp, Ye, type, nu, lambda), EPS)/(4.*M_PI);
+    const Real Bnu =
+        std::max(ThermalDistributionOfTNu(temp, type, nu, lambda), EPS);
+    const Real jnu =
+        std::max(J.EmissivityPerNu(rho, temp, Ye, type, nu, lambda), EPS) /
+        (4. * M_PI);
     return jnu / Bnu;
   }
 };

--- a/singularity-opac/neutrinos/tophat_emissivity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/tophat_emissivity_neutrinos.hpp
@@ -144,6 +144,18 @@ class TophatEmissivity {
     return 4 * M_PI * rho * Ac * GetYeF(type, Ye);
   }
 
+  PORTABLE_INLINE_FUNCTION
+  Real ThermalDistributionOfTNu(const Real temp, const RadiationType type,
+    const Real nu, Real *lambda = nullptr) const {
+      return dist_.ThermalDistributionOfTNu(temp, type, nu, lambda);
+    }
+
+  PORTABLE_INLINE_FUNCTION
+  Real ThermalDistributionOfT(const Real temp, const RadiationType type,
+    Real *lambda = nullptr) const {
+      return dist_.ThermalDistributionOfT(temp, type, lambda);
+    }
+
  private:
   PORTABLE_INLINE_FUNCTION
   Real GetYeF(RadiationType type, Real Ye) const {

--- a/singularity-opac/neutrinos/tophat_emissivity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/tophat_emissivity_neutrinos.hpp
@@ -51,18 +51,20 @@ class TophatEmissivity {
   inline void Finalize() noexcept {}
 
   PORTABLE_INLINE_FUNCTION
-  Real AbsorptionCoefficient(const Real rho, const Real temp,
-                                  const Real Ye, const RadiationType type,
-                                  const Real nu, Real *lambda = nullptr) const {
+  Real AbsorptionCoefficient(const Real rho, const Real temp, const Real Ye,
+                             const RadiationType type, const Real nu,
+                             Real *lambda = nullptr) const {
     return dist_.AbsorptionCoefficientFromKirkhoff(*this, rho, temp, Ye, type,
-                                                   nu, lambda)/(4.*M_PI);
+                                                   nu, lambda) /
+           (4. * M_PI);
   }
 
   template <typename FrequencyIndexer, typename DataIndexer>
-  PORTABLE_INLINE_FUNCTION void AbsorptionCoefficient(
-      const Real rho, const Real temp, const Real Ye, const RadiationType type,
-      FrequencyIndexer &nu_bins, DataIndexer &coeffs, const int nbins,
-      Real *lambda = nullptr) const {
+  PORTABLE_INLINE_FUNCTION void
+  AbsorptionCoefficient(const Real rho, const Real temp, const Real Ye,
+                        const RadiationType type, FrequencyIndexer &nu_bins,
+                        DataIndexer &coeffs, const int nbins,
+                        Real *lambda = nullptr) const {
     for (int i = 0; i < nbins; ++i) {
       coeffs[i] =
           AbsorptionCoefficient(rho, temp, Ye, type, nu_bins[i], lambda);
@@ -71,10 +73,12 @@ class TophatEmissivity {
 
   PORTABLE_INLINE_FUNCTION
   Real AngleAveragedAbsorptionCoefficient(const Real rho, const Real temp,
-                                  const Real Ye, const RadiationType type,
-                                  const Real nu, Real *lambda = nullptr) const {
-    return dist_.AngleAveragedAbsorptionCoefficientFromKirkhoff(*this, rho, temp, Ye, type,
-                                                   nu, lambda);
+                                          const Real Ye,
+                                          const RadiationType type,
+                                          const Real nu,
+                                          Real *lambda = nullptr) const {
+    return dist_.AngleAveragedAbsorptionCoefficientFromKirkhoff(
+        *this, rho, temp, Ye, type, nu, lambda);
   }
 
   template <typename FrequencyIndexer, typename DataIndexer>
@@ -83,8 +87,8 @@ class TophatEmissivity {
       FrequencyIndexer &nu_bins, DataIndexer &coeffs, const int nbins,
       Real *lambda = nullptr) const {
     for (int i = 0; i < nbins; ++i) {
-      coeffs[i] =
-          AngleAveragedAbsorptionCoefficient(rho, temp, Ye, type, nu_bins[i], lambda);
+      coeffs[i] = AngleAveragedAbsorptionCoefficient(rho, temp, Ye, type,
+                                                     nu_bins[i], lambda);
     }
   }
 
@@ -102,9 +106,9 @@ class TophatEmissivity {
   template <typename FrequencyIndexer, typename DataIndexer>
   PORTABLE_INLINE_FUNCTION void
   EmissivityPerNuOmega(const Real rho, const Real temp, const Real Ye,
-                       const RadiationType type,
-                       FrequencyIndexer &nu_bins, DataIndexer &coeffs,
-                       const int nbins, Real *lambda = nullptr) const {
+                       const RadiationType type, FrequencyIndexer &nu_bins,
+                       DataIndexer &coeffs, const int nbins,
+                       Real *lambda = nullptr) const {
     for (int i = 0; i < nbins; ++i) {
       coeffs[i] = EmissivityPerNuOmega(rho, temp, Ye, type, nu_bins[i], lambda);
     }
@@ -146,15 +150,20 @@ class TophatEmissivity {
 
   PORTABLE_INLINE_FUNCTION
   Real ThermalDistributionOfTNu(const Real temp, const RadiationType type,
-    const Real nu, Real *lambda = nullptr) const {
-      return dist_.ThermalDistributionOfTNu(temp, type, nu, lambda);
-    }
+                                const Real nu, Real *lambda = nullptr) const {
+    return dist_.ThermalDistributionOfTNu(temp, type, nu, lambda);
+  }
 
   PORTABLE_INLINE_FUNCTION
   Real ThermalDistributionOfT(const Real temp, const RadiationType type,
-    Real *lambda = nullptr) const {
-      return dist_.ThermalDistributionOfT(temp, type, lambda);
-    }
+                              Real *lambda = nullptr) const {
+    return dist_.ThermalDistributionOfT(temp, type, lambda);
+  }
+
+  PORTABLE_INLINE_FUNCTION Real ThermalNumberDistribution(
+      const Real temp, const RadiationType type, Real *lambda = nullptr) const {
+    return dist_.ThermalNumberDistribution(temp, type, lambda);
+  }
 
  private:
   PORTABLE_INLINE_FUNCTION

--- a/singularity-opac/photons/gray_opacity_photons.hpp
+++ b/singularity-opac/photons/gray_opacity_photons.hpp
@@ -120,6 +120,23 @@ class GrayOpacity {
     return kappa_ * dist_.ThermalNumberDistribution(temp, lambda);
   }
 
+  PORTABLE_INLINE_FUNCTION
+  Real ThermalDistributionOfTNu(const Real temp,
+                                const Real nu, Real *lambda = nullptr) const {
+    return dist_.ThermalDistributionOfTNu(temp, nu, lambda);
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real ThermalDistributionOfT(const Real temp,
+                              Real *lambda = nullptr) const {
+    return dist_.ThermalDistributionOfT(temp, lambda);
+  }
+
+  PORTABLE_INLINE_FUNCTION Real ThermalNumberDistribution(
+      const Real temp, Real *lambda = nullptr) const {
+    return dist_.ThermalNumberDistribution(temp, lambda);
+  }
+
  private:
   Real kappa_; // Opacity. Units of cm^2/g
   PlanckDistribution dist_;

--- a/singularity-opac/photons/gray_opacity_photons.hpp
+++ b/singularity-opac/photons/gray_opacity_photons.hpp
@@ -50,9 +50,10 @@ class GrayOpacity {
   }
 
   template <typename FrequencyIndexer, typename DataIndexer>
-  PORTABLE_INLINE_FUNCTION void AbsorptionCoefficientPerNu(
-      const Real rho, const Real temp, FrequencyIndexer &nu_bins,
-      DataIndexer &coeffs, const int nbins, Real *lambda = nullptr) const {
+  PORTABLE_INLINE_FUNCTION void
+  AbsorptionCoefficientPerNu(const Real rho, const Real temp,
+                             FrequencyIndexer &nu_bins, DataIndexer &coeffs,
+                             const int nbins, Real *lambda = nullptr) const {
     for (int i = 0; i < nbins; ++i) {
       coeffs[i] = AbsorptionCoefficientPerNu(rho, temp, nu_bins[i], lambda);
     }
@@ -60,9 +61,10 @@ class GrayOpacity {
 
   PORTABLE_INLINE_FUNCTION
   Real AngleAveragedAbsorptionCoefficientPerNu(const Real rho, const Real temp,
-                                  const Real nu, Real *lambda = nullptr) const {
-    return dist_.AngleAveragedAbsorptionCoefficientFromKirkhoff(*this, rho, temp, nu,
-                                                   lambda);
+                                               const Real nu,
+                                               Real *lambda = nullptr) const {
+    return dist_.AngleAveragedAbsorptionCoefficientFromKirkhoff(
+        *this, rho, temp, nu, lambda);
   }
 
   template <typename FrequencyIndexer, typename DataIndexer>
@@ -70,7 +72,8 @@ class GrayOpacity {
       const Real rho, const Real temp, FrequencyIndexer &nu_bins,
       DataIndexer &coeffs, const int nbins, Real *lambda = nullptr) const {
     for (int i = 0; i < nbins; ++i) {
-      coeffs[i] = AngleAveragedAbsorptionCoefficientPerNu(rho, temp, nu_bins[i], lambda);
+      coeffs[i] = AngleAveragedAbsorptionCoefficientPerNu(rho, temp, nu_bins[i],
+                                                          lambda);
     }
   }
 
@@ -99,9 +102,9 @@ class GrayOpacity {
 
   template <typename FrequencyIndexer, typename DataIndexer>
   PORTABLE_INLINE_FUNCTION void
-  EmissivityPerNu(const Real rho, const Real temp,
-                  FrequencyIndexer &nu_bins, DataIndexer &coeffs,
-                  const int nbins, Real *lambda = nullptr) const {
+  EmissivityPerNu(const Real rho, const Real temp, FrequencyIndexer &nu_bins,
+                  DataIndexer &coeffs, const int nbins,
+                  Real *lambda = nullptr) const {
     for (int i = 0; i < nbins; ++i) {
       coeffs[i] = EmissivityPerNu(rho, temp, nu_bins[i], lambda);
     }
@@ -121,19 +124,18 @@ class GrayOpacity {
   }
 
   PORTABLE_INLINE_FUNCTION
-  Real ThermalDistributionOfTNu(const Real temp,
-                                const Real nu, Real *lambda = nullptr) const {
+  Real ThermalDistributionOfTNu(const Real temp, const Real nu,
+                                Real *lambda = nullptr) const {
     return dist_.ThermalDistributionOfTNu(temp, nu, lambda);
   }
 
   PORTABLE_INLINE_FUNCTION
-  Real ThermalDistributionOfT(const Real temp,
-                              Real *lambda = nullptr) const {
+  Real ThermalDistributionOfT(const Real temp, Real *lambda = nullptr) const {
     return dist_.ThermalDistributionOfT(temp, lambda);
   }
 
-  PORTABLE_INLINE_FUNCTION Real ThermalNumberDistribution(
-      const Real temp, Real *lambda = nullptr) const {
+  PORTABLE_INLINE_FUNCTION Real
+  ThermalNumberDistribution(const Real temp, Real *lambda = nullptr) const {
     return dist_.ThermalNumberDistribution(temp, lambda);
   }
 

--- a/singularity-opac/photons/non_cgs_photons.hpp
+++ b/singularity-opac/photons/non_cgs_photons.hpp
@@ -167,15 +167,14 @@ class NonCGSUnits {
   }
 
   PORTABLE_INLINE_FUNCTION
-  Real ThermalDistributionOfTNu(const Real temp,
-                                const Real nu, Real *lambda = nullptr) const {
+  Real ThermalDistributionOfTNu(const Real temp, const Real nu,
+                                Real *lambda = nullptr) const {
     Real BoH = opac_.ThermalDistributionOfTNu(temp, nu, lambda);
     return BoH * inv_intensity_unit_;
   }
 
   PORTABLE_INLINE_FUNCTION
-  Real ThermalDistributionOfT(const Real temp,
-                              Real *lambda = nullptr) const {
+  Real ThermalDistributionOfT(const Real temp, Real *lambda = nullptr) const {
     Real BoH = opac_.ThermalDistributionOfT(temp, lambda);
     return BoH * inv_energy_dens_unit_;
   }

--- a/singularity-opac/photons/non_cgs_photons.hpp
+++ b/singularity-opac/photons/non_cgs_photons.hpp
@@ -166,10 +166,32 @@ class NonCGSUnits {
     return JoH * inv_num_emiss_unit_;
   }
 
+  PORTABLE_INLINE_FUNCTION
+  Real ThermalDistributionOfTNu(const Real temp,
+                                const Real nu, Real *lambda = nullptr) const {
+    Real BoH = opac_.ThermalDistributionOfTNu(temp, nu, lambda);
+    return BoH * inv_intensity_unit_;
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real ThermalDistributionOfT(const Real temp,
+                              Real *lambda = nullptr) const {
+    Real BoH = opac_.ThermalDistributionOfT(temp, lambda);
+    return BoH * inv_energy_dens_unit_;
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real ThermalNumberDistribution(const Real temp,
+                                 Real *lambda = nullptr) const {
+    Real NoH = opac_.ThermalNumberDistribution(temp, lambda);
+    return NoH * mass_unit_ / rho_unit_;
+  }
+
  private:
   Opac opac_;
   Real time_unit_, mass_unit_, length_unit_, temp_unit_;
   Real rho_unit_, freq_unit_, inv_emiss_unit_, inv_num_emiss_unit_;
+  Real inv_intensity_unit_, inv_energy_dens_unit_;
 };
 
 } // namespace photons

--- a/singularity-opac/photons/opac_photons.hpp
+++ b/singularity-opac/photons/opac_photons.hpp
@@ -16,11 +16,10 @@
 #ifndef SINGULARITY_OPAC_PHOTONS_OPAC_PHOTONS_
 #define SINGULARITY_OPAC_PHOTONS_OPAC_PHOTONS_
 
-
 #include <singularity-opac/photons/gray_opacity_photons.hpp>
+#include <singularity-opac/photons/non_cgs_photons.hpp>
 #include <singularity-opac/photons/photon_variant.hpp>
 #include <singularity-opac/photons/thermal_distributions_photons.hpp>
-#include <singularity-opac/photons/non_cgs_photons.hpp>
 
 namespace singularity {
 namespace photons {

--- a/singularity-opac/photons/photon_variant.hpp
+++ b/singularity-opac/photons/photon_variant.hpp
@@ -77,7 +77,7 @@ class Variant {
   // rho, temp, nu, lambda
   PORTABLE_INLINE_FUNCTION Real
   AbsorptionCoefficient(const Real rho, const Real temp, const Real nu,
-                             Real *lambda = nullptr) const {
+                        Real *lambda = nullptr) const {
     return mpark::visit(
         [=](const auto &opac) {
           return opac.AbsorptionCoefficient(rho, temp, nu, lambda);
@@ -86,13 +86,13 @@ class Variant {
   }
 
   template <typename FrequencyIndexer, typename DataIndexer>
-  PORTABLE_INLINE_FUNCTION void AbsorptionCoefficient(
-      const Real rho, const Real temp, FrequencyIndexer &nu_bins,
-      DataIndexer &coeffs, const int nbins, Real *lambda = nullptr) const {
+  PORTABLE_INLINE_FUNCTION void
+  AbsorptionCoefficient(const Real rho, const Real temp,
+                        FrequencyIndexer &nu_bins, DataIndexer &coeffs,
+                        const int nbins, Real *lambda = nullptr) const {
     mpark::visit(
         [&](const auto &opac) {
-          opac.AbsorptionCoefficient(rho, temp, nu_bins, coeffs, nbins,
-                                          lambda);
+          opac.AbsorptionCoefficient(rho, temp, nu_bins, coeffs, nbins, lambda);
         },
         opac_);
   }
@@ -101,25 +101,23 @@ class Variant {
   // Signature should be at least
   // rho, temp, nu, lambda
   PORTABLE_INLINE_FUNCTION Real AngleAveragedAbsorptionCoefficient(
-      const Real rho, const Real temp,
-      const Real nu, Real *lambda = nullptr) const {
+      const Real rho, const Real temp, const Real nu,
+      Real *lambda = nullptr) const {
     return mpark::visit(
         [=](const auto &opac) {
-          return opac.AngleAveragedAbsorptionCoefficient(rho, temp, nu,
-                                                 lambda);
+          return opac.AngleAveragedAbsorptionCoefficient(rho, temp, nu, lambda);
         },
         opac_);
   }
 
   template <typename FrequencyIndexer, typename DataIndexer>
   PORTABLE_INLINE_FUNCTION void AngleAveragedAbsorptionCoefficient(
-      const Real rho, const Real temp,
-      FrequencyIndexer &nu_bins, DataIndexer &coeffs, const int nbins,
-      Real *lambda = nullptr) const {
+      const Real rho, const Real temp, FrequencyIndexer &nu_bins,
+      DataIndexer &coeffs, const int nbins, Real *lambda = nullptr) const {
     mpark::visit(
         [&](const auto &opac) {
           opac.AngleAveragedAbsorptionCoefficient(rho, temp, nu_bins, coeffs,
-                                          nbins, lambda);
+                                                  nbins, lambda);
         },
         opac_);
   }
@@ -162,9 +160,9 @@ class Variant {
 
   template <typename FrequencyIndexer, typename DataIndexer>
   PORTABLE_INLINE_FUNCTION void
-  EmissivityPerNu(const Real rho, const Real temp,
-                  FrequencyIndexer &nu_bins, DataIndexer &coeffs,
-                  const int nbins, Real *lambda = nullptr) const {
+  EmissivityPerNu(const Real rho, const Real temp, FrequencyIndexer &nu_bins,
+                  DataIndexer &coeffs, const int nbins,
+                  Real *lambda = nullptr) const {
     mpark::visit(
         [&](const auto &opac) {
           return opac.EmissivityPerNu(rho, temp, nu_bins, coeffs, nbins,
@@ -193,34 +191,34 @@ class Variant {
   }
 
   // Specific intensity of thermal distribution
-  PORTABLE_INLINE_FUNCTION Real ThermalDistributionOfTNu(const Real temp,
-   const Real nu, Real *lambda = nullptr) const {
-     return mpark::visit(
-       [=](const auto &opac) {
-         return opac.ThermalDistributionOfTNu(temp, nu, lambda);
-       },
-       opac_);
-   }
+  PORTABLE_INLINE_FUNCTION Real ThermalDistributionOfTNu(
+      const Real temp, const Real nu, Real *lambda = nullptr) const {
+    return mpark::visit(
+        [=](const auto &opac) {
+          return opac.ThermalDistributionOfTNu(temp, nu, lambda);
+        },
+        opac_);
+  }
 
   // Energy density of thermal distribution
-  PORTABLE_INLINE_FUNCTION Real ThermalDistributionOfT(const Real temp,
-   Real *lambda = nullptr) const {
-     return mpark::visit(
-       [=](const auto &opac) {
-         return opac.ThermalDistributionOfT(temp, lambda);
-       },
-       opac_);
-   }
+  PORTABLE_INLINE_FUNCTION Real
+  ThermalDistributionOfT(const Real temp, Real *lambda = nullptr) const {
+    return mpark::visit(
+        [=](const auto &opac) {
+          return opac.ThermalDistributionOfT(temp, lambda);
+        },
+        opac_);
+  }
 
   // Number density of thermal distribution
-  PORTABLE_INLINE_FUNCTION Real ThermalNumberDistribution(const Real temp,
-   Real *lambda = nullptr) const {
-     return mpark::visit(
-       [=](const auto &opac) {
-         return opac.ThermalNumberDistribution(temp, lambda);
-       },
-       opac_);
-   }
+  PORTABLE_INLINE_FUNCTION Real
+  ThermalNumberDistribution(const Real temp, Real *lambda = nullptr) const {
+    return mpark::visit(
+        [=](const auto &opac) {
+          return opac.ThermalNumberDistribution(temp, lambda);
+        },
+        opac_);
+  }
 
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept {

--- a/singularity-opac/photons/photon_variant.hpp
+++ b/singularity-opac/photons/photon_variant.hpp
@@ -192,6 +192,36 @@ class Variant {
         opac_);
   }
 
+  // Specific intensity of thermal distribution
+  PORTABLE_INLINE_FUNCTION Real ThermalDistributionOfTNu(const Real temp,
+   const Real nu, Real *lambda = nullptr) const {
+     return mpark::visit(
+       [=](const auto &opac) {
+         return opac.ThermalDistributionOfTNu(temp, nu, lambda);
+       },
+       opac_);
+   }
+
+  // Energy density of thermal distribution
+  PORTABLE_INLINE_FUNCTION Real ThermalDistributionOfT(const Real temp,
+   Real *lambda = nullptr) const {
+     return mpark::visit(
+       [=](const auto &opac) {
+         return opac.ThermalDistributionOfT(temp, lambda);
+       },
+       opac_);
+   }
+
+  // Number density of thermal distribution
+  PORTABLE_INLINE_FUNCTION Real ThermalNumberDistribution(const Real temp,
+   Real *lambda = nullptr) const {
+     return mpark::visit(
+       [=](const auto &opac) {
+         return opac.ThermalNumberDistribution(temp, lambda);
+       },
+       opac_);
+   }
+
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept {
     return mpark::visit([](const auto &opac) { return opac.nlambda(); }, opac_);

--- a/singularity-opac/photons/thermal_distributions_photons.hpp
+++ b/singularity-opac/photons/thermal_distributions_photons.hpp
@@ -61,7 +61,7 @@ struct PlanckDistribution {
       const Emissivity &J, const Real rho, const Real temp, const Real nu,
       Real *lambda = nullptr) const {
     Real Bnu = ThermalDistributionOfTNu(temp, nu, lambda);
-    Real jnu = J.EmissivityPerNu(rho, temp, nu, lambda)/(4.*M_PI);
+    Real jnu = J.EmissivityPerNu(rho, temp, nu, lambda) / (4. * M_PI);
     return jnu / Bnu;
   }
 };

--- a/test/test_spiner_opac_neutrinos.cpp
+++ b/test/test_spiner_opac_neutrinos.cpp
@@ -83,11 +83,11 @@ TEST_CASE("Spiner opacities, filled with gray data",
     Grid_t leGrid(leMin, leMax, Ne);
 
     neutrinos::Opacity gray = neutrinos::Gray(kappa);
-    neutrinos::SpinerOpacity filled(gray, lRhoMin, lRhoMax, NRho, lTMin, lTMax,
-                                    NT, YeMin, YeMax, NYe, leMin, leMax, Ne);
+    neutrinos::SpinerOpac filled(gray, lRhoMin, lRhoMax, NRho, lTMin, lTMax, NT,
+                                 YeMin, YeMax, NYe, leMin, leMax, Ne);
 
     THEN("The table matches the gray opacities") {
-      neutrinos::SpinerOpacity opac = filled.GetOnDevice();
+      neutrinos::SpinerOpac opac = filled.GetOnDevice();
       int n_wrong = 0;
       portableReduce(
           "table vs gray depends nu", 0, NRho, 0, NT, 0, NYe, 0,
@@ -101,7 +101,7 @@ TEST_CASE("Spiner opacities, filled with gray data",
             const Real Ye = YeGrid.x(iYe);
             const Real le = leGrid.x(ie);
             const Real e = std::pow(10, le);
-            const Real nu = e * neutrinos::SpinerOpacity::MeV2Hz;
+            const Real nu = e * neutrinos::SpinerOpac::MeV2Hz;
             const RadiationType type = Idx2RadType(itp);
 
             // alphanu
@@ -137,10 +137,10 @@ TEST_CASE("Spiner opacities, filled with gray data",
           "fill nu bins", 0, Ne, PORTABLE_LAMBDA(const int ie) {
             const Real le = leGrid.x(ie);
             const Real e = std::pow(10, le);
-            nu_bins[ie] = e * neutrinos::SpinerOpacity::MeV2Hz;
+            nu_bins[ie] = e * neutrinos::SpinerOpac::MeV2Hz;
           });
 
-      n_wrong = 0;      
+      n_wrong = 0;
       portableReduce(
           "table vs gray indexer API", 0, NRho, 0, NT, 0, NYe, 0,
           NEUTRINO_NTYPES,
@@ -156,8 +156,8 @@ TEST_CASE("Spiner opacities, filled with gray data",
             Real data_tabl[Ne];
 
             // alphanu
-            gray.AbsorptionCoefficient(rho, T, Ye, type, nu_bins,
-                                       data_gray, Ne);
+            gray.AbsorptionCoefficient(rho, T, Ye, type, nu_bins, data_gray,
+                                       Ne);
             opac.AbsorptionCoefficient(rho, T, Ye, type, nu_bins, data_tabl,
                                        Ne);
             for (int ie = 0; ie < Ne; ++ie) {
@@ -169,8 +169,8 @@ TEST_CASE("Spiner opacities, filled with gray data",
             // Alphanu
             gray.AngleAveragedAbsorptionCoefficient(rho, T, Ye, type, nu_bins,
                                                     data_gray, Ne);
-            opac.AngleAveragedAbsorptionCoefficient(
-                rho, T, Ye, type, nu_bins, data_tabl, Ne);
+            opac.AngleAveragedAbsorptionCoefficient(rho, T, Ye, type, nu_bins,
+                                                    data_tabl, Ne);
             for (int ie = 0; ie < Ne; ++ie) {
               if (IsWrong(data_gray[ie], data_tabl[ie])) {
                 accumulate += 1;
@@ -178,10 +178,8 @@ TEST_CASE("Spiner opacities, filled with gray data",
             }
 
             // jnu
-            gray.EmissivityPerNuOmega(rho, T, Ye, type, nu_bins, data_gray,
-                                      Ne);
-            opac.EmissivityPerNuOmega(rho, T, Ye, type, nu_bins, data_tabl,
-                                      Ne);
+            gray.EmissivityPerNuOmega(rho, T, Ye, type, nu_bins, data_gray, Ne);
+            opac.EmissivityPerNuOmega(rho, T, Ye, type, nu_bins, data_tabl, Ne);
             for (int ie = 0; ie < Ne; ++ie) {
               if (IsWrong(data_gray[ie], data_tabl[ie])) {
                 accumulate += 1;
@@ -236,7 +234,7 @@ TEST_CASE("Spiner opacities, filled with gray data",
 #ifdef SPINER_USE_HDF
     THEN("We can save to disk and reload") {
       filled.Save(grayname);
-      neutrinos::Opacity opac_host = neutrinos::SpinerOpacity(grayname);
+      neutrinos::Opacity opac_host = neutrinos::SpinerOpac(grayname);
       AND_THEN("The reloaded table matches the gray opacities") {
 
         neutrinos::Opacity opac = opac_host.GetOnDevice();
@@ -254,7 +252,7 @@ TEST_CASE("Spiner opacities, filled with gray data",
               const Real Ye = YeGrid.x(iYe);
               const Real le = leGrid.x(ie);
               const Real e = std::pow(10, le);
-              const Real nu = e * neutrinos::SpinerOpacity::MeV2Hz;
+              const Real nu = e * neutrinos::SpinerOpac::MeV2Hz;
               const RadiationType type = Idx2RadType(itp);
               const Real Jgray =
                   gray.EmissivityPerNuOmega(rho, T, Ye, type, nu);


### PR DESCRIPTION
It can be useful for codes digesting opacities to have access to the underlying thermal distributions. For example, in gray moment methods, interactions are often expressed in terms of relaxation to the frequency- and angle-averaged thermal specific intensity.