### PR TITLE
Add realistic analytic neutrino opacity

### DIFF
--- a/singularity-opac/neutrinos/brt_neutrinos.hpp
+++ b/singularity-opac/neutrinos/brt_neutrinos.hpp
@@ -155,7 +155,8 @@ class BRTOpacity {
            pow((pc::h * nu + Deltanp_) / (pc::me * pc::c * pc::c), 2);
   }
 
-  Real GetAlphac(const Real rho, const Real temp, const RadiationType type) const {
+  Real GetAlphac(const Real rho, const Real temp,
+                 const RadiationType type) const {
     if (type != RadiationType::NU_ELECTRON) {
       return 0.;
     }
@@ -168,7 +169,8 @@ class BRTOpacity {
     return retval;
   }
 
-  Real GetNAlphac(const Real rho, const Real temp, const RadiationType type) const {
+  Real GetNAlphac(const Real rho, const Real temp,
+                  const RadiationType type) const {
     Real retval = (1. + 3. * gA_ * gA_) * pow(pc::kb * temp, 3) * rho * sigma0_;
     retval *= (7. * pc::kb * pow(M_PI, 4) * temp * Deltanp_ +
                90. * pow(Deltanp_, 2) * zeta3_ +

--- a/singularity-opac/neutrinos/brt_neutrinos.hpp
+++ b/singularity-opac/neutrinos/brt_neutrinos.hpp
@@ -140,9 +140,9 @@ class BRTOpacity {
     return dist_.ThermalDistributionOfT(temp, type, lambda);
   }
 
-  PORTABLE_INLINE_FUNCTION Real ThermalNumberDistribution(
+  PORTABLE_INLINE_FUNCTION Real ThermalNumberDistributionOfT(
       const Real temp, const RadiationType type, Real *lambda = nullptr) const {
-    return dist_.ThermalNumberDistribution(temp, type, lambda);
+    return dist_.ThermalNumberDistributionOfT(temp, type, lambda);
   }
 
  private:
@@ -155,7 +155,7 @@ class BRTOpacity {
            pow((pc::h * nu + Deltanp_) / (pc::me * pc::c * pc::c), 2);
   }
 
-  Real GetAlphac(const Real rho, const Real temp, const RadiationType type) {
+  Real GetAlphac(const Real rho, const Real temp, const RadiationType type) const {
     if (type != RadiationType::NU_ELECTRON) {
       return 0.;
     }
@@ -168,7 +168,7 @@ class BRTOpacity {
     return retval;
   }
 
-  Real GetNAlphac(const Real rho, const Real temp, const RadiationType type) {
+  Real GetNAlphac(const Real rho, const Real temp, const RadiationType type) const {
     Real retval = (1. + 3. * gA_ * gA_) * pow(pc::kb * temp, 3) * rho * sigma0_;
     retval *= (7. * pc::kb * pow(M_PI, 4) * temp * Deltanp_ +
                90. * pow(Deltanp_, 2) * zeta3_ +

--- a/singularity-opac/neutrinos/brt_neutrinos.hpp
+++ b/singularity-opac/neutrinos/brt_neutrinos.hpp
@@ -1,0 +1,171 @@
+// ======================================================================
+// © 2021. Triad National Security, LLC. All rights reserved.  This
+// program was produced under U.S. Government contract
+// 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
+// is operated by Triad National Security, LLC for the U.S.
+// Department of Energy/National Nuclear Security Administration. All
+// rights in the program are reserved by Triad National Security, LLC,
+// and the U.S. Department of Energy/National Nuclear Security
+// Administration. The Government is granted for itself and others
+// acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works,
+// distribute copies to the public, perform publicly and display
+// publicly, and to permit others to do so.
+// ======================================================================
+
+#ifndef SINGULARITY_OPAC_NEUTRINOS_BRT_NEUTRINOS_
+#define SINGULARITY_OPAC_NEUTRINOS_BRT_NEUTRINOS_
+
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+
+#include <ports-of-call/portability.hpp>
+#include <singularity-opac/base/opac_error.hpp>
+#include <singularity-opac/neutrinos/thermal_distributions_neutrinos.hpp>
+
+namespace singularity {
+namespace neutrinos {
+
+using pc = PhysicalConstants<CGS>;
+
+// Neutrino electron absorption from Burrows, Reddy, & Thompson 2004
+template <typename ThermalDistribution>
+class BRTOpacity {
+ public:
+  BRTOpacity() = default;
+  BRTOpacity GetOnDevice() { return *this; }
+  PORTABLE_INLINE_FUNCTION
+  int nlambda() const noexcept { return 0; }
+  PORTABLE_INLINE_FUNCTION
+  void PrintParams() const noexcept {
+    printf("Burrows-Reddy-Thompson analytic neutrino opacity.\n");
+  }
+  inline void Finalize() noexcept {}
+
+  PORTABLE_INLINE_FUNCTION
+  Real AbsorptionCoefficient(const Real rho, const Real temp, const Real Ye,
+                             const RadiationType type, const Real nu,
+                             Real *lambda = nullptr) const {
+    return rho / mu_ * GetSigmac(type, nu);
+  }
+    template <typename FrequencyIndexer, typename DataIndexer>
+  PORTABLE_INLINE_FUNCTION void
+  AbsorptionCoefficient(const Real rho, const Real temp, const Real Ye,
+                        const RadiationType type, FrequencyIndexer &nu_bins,
+                        DataIndexer &coeffs, const int nbins,
+                        Real *lambda = nullptr) const {
+    for (int i = 0; i < nbins; ++i) {
+      coeffs[i] = rho / mu_ * GetSigmac(type, nu_bins[i]);
+    }
+  }
+
+    PORTABLE_INLINE_FUNCTION
+  Real AngleAveragedAbsorptionCoefficient(const Real rho, const Real temp,
+                                          const Real Ye,
+                                          const RadiationType type,
+                                          const Real nu,
+                                          Real *lambda = nullptr) const {
+    return rho / mu_ * GetSigmac(type, nu);
+  }
+
+    template <typename FrequencyIndexer, typename DataIndexer>
+  PORTABLE_INLINE_FUNCTION void AngleAveragedAbsorptionCoefficient(
+      const Real rho, const Real temp, const Real Ye, const RadiationType type,
+      FrequencyIndexer &nu_bins, DataIndexer &coeffs, const int nbins,
+      Real *lambda = nullptr) const {
+    for (int i = 0; i < nbins; ++i) {
+      coeffs[i] = rho / mu_ * GetSigmac(type, nu_bins[i]);
+    }
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real EmissivityPerNuOmega(const Real rho, const Real temp, const Real Ye,
+                            const RadiationType type, const Real nu,
+                            Real *lambda = nullptr) const {
+    Real Bnu = dist_.ThermalDistributionOfTNu(temp, type, nu, lambda);
+    return rho / mu_ * GetSigmac(type, nu) * Bnu;
+  }
+
+    template <typename FrequencyIndexer, typename DataIndexer>
+  PORTABLE_INLINE_FUNCTION void
+  EmissivityPerNuOmega(const Real rho, const Real temp, const Real Ye,
+                       const RadiationType type, FrequencyIndexer &nu_bins,
+                       DataIndexer &coeffs, const int nbins,
+                       Real *lambda = nullptr) const {
+    for (int i = 0; i < nbins; ++i) {
+      coeffs[i] = EmissivityPerNuOmega(rho, temp, Ye, type, nu_bins[i], lambda);
+    }
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real EmissivityPerNu(const Real rho, const Real temp, const Real Ye,
+                       const RadiationType type, const Real nu,
+                       Real *lambda = nullptr) const {
+    return 4 * M_PI * EmissivityPerNuOmega(rho, temp, Ye, type, nu, lambda);
+  }
+
+  template <typename FrequencyIndexer, typename DataIndexer>
+  PORTABLE_INLINE_FUNCTION void
+  EmissivityPerNu(const Real rho, const Real temp, const Real Ye,
+                  const RadiationType type, FrequencyIndexer &nu_bins,
+                  DataIndexer &coeffs, const int nbins,
+                  Real *lambda = nullptr) const {
+    for (int i = 0; i < nbins; ++i) {
+      coeffs[i] = EmissivityPerNu(rho, temp, Ye, type, nu_bins[i], lambda);
+    }
+  }
+    PORTABLE_INLINE_FUNCTION
+  Real Emissivity(const Real rho, const Real temp, const Real Ye,
+                  const RadiationType type, Real *lambda = nullptr) const {
+    Real B = dist_.ThermalDistributionOfT(temp, type, lambda);
+    return 4 * M_PI * rho * 0. * B;
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real NumberEmissivity(const Real rho, const Real temp, Real Ye,
+                        RadiationType type, Real *lambda = nullptr) const {
+    return 4 * M_PI * 0. *
+           dist_.ThermalNumberDistribution(temp, type, lambda);
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real ThermalDistributionOfTNu(const Real temp, const RadiationType type,
+                                const Real nu, Real *lambda = nullptr) const {
+    return dist_.ThermalDistributionOfTNu(temp, type, nu, lambda);
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real ThermalDistributionOfT(const Real temp, const RadiationType type,
+                              Real *lambda = nullptr) const {
+    return dist_.ThermalDistributionOfT(temp, type, lambda);
+  }
+
+  PORTABLE_INLINE_FUNCTION Real ThermalNumberDistribution(
+      const Real temp, const RadiationType type, Real *lambda = nullptr) const {
+    return dist_.ThermalNumberDistribution(temp, type, lambda);
+  }
+
+ private:
+  Real GetSigmac(const RadiationType type, const Real nu) const {
+    if (type != RadiationType::NU_ELECTRON) {
+      return 0.;
+    }
+    printf("nu: %e type: %i sigma0_: %e\n", nu, static_cast<int>(type), sigma0_);
+    printf("hbar*c: %e me*c^2: %e\n", pc::hbar*pc::c, pc::me*pc::c*pc::c);
+
+    return sigma0_;
+  }
+  const Real Fc_ =
+      4.543791885043567014e+00; // Fermi coupling constant. Units of erg^-2
+  const Real sigma0_ = 4. * Fc_ * Fc_ * pc::c * pc::c * pc::hbar * pc::hbar *
+                       pc::me * pc::me * pc::c * pc::c * pc::c * pc::c /
+                       M_PI; // Fiducial weak cross section. Units of cm^2
+  const Real mu_ = pc::mp;
+  ThermalDistribution dist_;
+};
+
+} // namespace neutrinos
+} // namespace singularity
+
+#endif // SINGULARITY_OPAC_NEUTRINOS_BRT_NEUTRINOS_

--- a/singularity-opac/neutrinos/opac_neutrinos.hpp
+++ b/singularity-opac/neutrinos/opac_neutrinos.hpp
@@ -18,6 +18,7 @@
 
 #include <variant/include/mpark/variant.hpp>
 
+#include <singularity-opac/neutrinos/brt_neutrinos.hpp>
 #include <singularity-opac/neutrinos/gray_opacity_neutrinos.hpp>
 #include <singularity-opac/neutrinos/neutrino_variant.hpp>
 #include <singularity-opac/neutrinos/non_cgs_neutrinos.hpp>
@@ -29,11 +30,13 @@ namespace singularity {
 namespace neutrinos {
 
 // TODO(JMM): Include chemical potential
+using BRTOpac = BRTOpacity<FermiDiracDistributionNoMu<3>>;
 using Gray = GrayOpacity<FermiDiracDistributionNoMu<3>>;
 using Tophat = TophatEmissivity<FermiDiracDistributionNoMu<3>>;
 using SpinerOpac = SpinerOpacity<FermiDiracDistributionNoMu<3>>;
 
-using Opacity = impl::Variant<Gray, Tophat, SpinerOpac, NonCGSUnits<Gray>,
+using Opacity = impl::Variant<BRTOpac, Gray, Tophat, SpinerOpac,
+                              NonCGSUnits<BRTOpac>, NonCGSUnits<Gray>,
                               NonCGSUnits<Tophat>, NonCGSUnits<SpinerOpac>>;
 
 } // namespace neutrinos

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,6 +36,7 @@ target_sources(${PROJECT_NAME}_unit_tests
 PRIVATE
   test_trivial.cpp
   test_gray_opacities.cpp
+  test_brt_opacities.cpp
   test_chebyshev.cpp
   test_spiner_opac_neutrinos.cpp
 )

--- a/test/test_brt_opacities.cpp
+++ b/test/test_brt_opacities.cpp
@@ -1,0 +1,196 @@
+// ======================================================================
+// © 2021. Triad National Security, LLC. All rights reserved.  This
+// program was produced under U.S. Government contract
+// 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
+// is operated by Triad National Security, LLC for the U.S.
+// Department of Energy/National Nuclear Security Administration. All
+// rights in the program are reserved by Triad National Security, LLC,
+// and the U.S. Department of Energy/National Nuclear Security
+// Administration. The Government is granted for itself and others
+// acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works,
+// distribute copies to the public, perform publicly and display
+// publicly, and to permit others to do so.
+// ======================================================================
+
+#include <cmath>
+#include <iostream>
+
+#include <catch2/catch.hpp>
+
+#include <ports-of-call/portability.hpp>
+#include <ports-of-call/portable_arrays.hpp>
+#include <spiner/databox.hpp>
+
+#include <singularity-opac/base/indexers.hpp>
+#include <singularity-opac/base/radiation_types.hpp>
+#include <singularity-opac/chebyshev/chebyshev.hpp>
+#include <singularity-opac/constants/constants.hpp>
+#include <singularity-opac/neutrinos/opac_neutrinos.hpp>
+#include <singularity-opac/photons/opac_photons.hpp>
+
+using namespace singularity;
+
+using pc = PhysicalConstants<CGS>;
+
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+using atomic_view = Kokkos::MemoryTraits<Kokkos::Atomic>;
+#endif
+
+template <typename T>
+PORTABLE_INLINE_FUNCTION T FractionalDifference(const T &a, const T &b) {
+  return 2 * std::abs(b - a) / (std::abs(a) + std::abs(b) + 1e-20);
+}
+constexpr Real EPS_TEST = 1e-3;
+
+TEST_CASE("BRT neutrino opacities", "[BRTNeutrinos]") {
+  WHEN("We initialize a Burrows-Reddy-Thompson neutrino opacity") {
+    constexpr Real MeV2K = 1e6 * pc::eV / pc::kb;
+    constexpr Real MeV2Hz = 1e6 * pc::eV / pc::h;
+    constexpr Real rho = 1e11;        // g/cc
+    constexpr Real temp = 10 * MeV2K; // 10 MeV
+    constexpr Real Ye = 0.1;
+    constexpr RadiationType type = RadiationType::NU_ELECTRON;
+    constexpr Real nu = 1.25 * MeV2Hz; // 1 MeV
+
+    neutrinos::BRTOpac opac_host;
+    neutrinos::Opacity opac = opac_host.GetOnDevice();
+
+    THEN("The emissivity per nu omega is consistent with the emissity per nu") {
+      int n_wrong_h = 0;
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+      Kokkos::View<int, atomic_view> n_wrong_d("wrong");
+#else
+      PortableMDArray<int> n_wrong_d(&n_wrong_h, 1);
+#endif
+
+      portableFor(
+          "calc emissivities", 0, 100, PORTABLE_LAMBDA(const int &i) {
+            Real jnu = opac.EmissivityPerNuOmega(rho, temp, Ye, type, nu);
+            Real Jnu = opac.EmissivityPerNu(rho, temp, Ye, type, nu);
+            printf("jnu: %e Jnu: %e\n", jnu, Jnu);
+            if (FractionalDifference(Jnu, 4 * M_PI * jnu) > EPS_TEST) {
+              n_wrong_d() += 1;
+            }
+          });
+
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+      Kokkos::deep_copy(n_wrong_h, n_wrong_d);
+#endif
+      REQUIRE(n_wrong_h == 0);
+    }
+
+    WHEN("We create a gray opacity object in non-cgs units") {
+      constexpr Real time_unit = 123;
+      constexpr Real mass_unit = 456;
+      constexpr Real length_unit = 789;
+      constexpr Real temp_unit = 276;
+      constexpr Real rho_unit =
+          mass_unit / (length_unit * length_unit * length_unit);
+      constexpr Real j_unit = mass_unit / (length_unit * time_unit * time_unit);
+      neutrinos::Opacity funny_units_host =
+          neutrinos::NonCGSUnits<neutrinos::BRTOpac>(
+              neutrinos::BRTOpac(), time_unit, mass_unit, length_unit, temp_unit);
+      auto funny_units = funny_units_host.GetOnDevice();
+
+      THEN("We can convert meaningfully into and out of funny units") {
+        int n_wrong_h = 0;
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+        Kokkos::View<int, atomic_view> n_wrong_d("wrong");
+#else
+        PortableMDArray<int> n_wrong_d(&n_wrong_h, 1);
+#endif
+
+        portableFor(
+            "emissivities in funny units", 0, 100,
+            PORTABLE_LAMBDA(const int &i) {
+              Real jnu_funny = funny_units.EmissivityPerNuOmega(
+                  rho / rho_unit, temp / temp_unit, Ye, type, nu * time_unit);
+              Real jnu = opac.EmissivityPerNuOmega(rho, temp, Ye, type, nu);
+              if (FractionalDifference(jnu, jnu_funny * j_unit) > EPS_TEST) {
+                n_wrong_d() += 1;
+              }
+            });
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+        Kokkos::deep_copy(n_wrong_h, n_wrong_d);
+#endif
+        REQUIRE(n_wrong_h == 0);
+      }
+    }
+
+    THEN("We can fill an indexer allocated in a cell") {
+      int n_wrong_h = 0;
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+      Kokkos::View<int, atomic_view> n_wrong_d("wrong");
+#else
+      PortableMDArray<int> n_wrong_d(&n_wrong_h, 1);
+#endif
+      constexpr int nbins = 9;
+      constexpr int ntemps = 100;
+
+      Real lnu_min = 0 + std::log10(MeV2Hz);
+      Real lnu_max = 1 + std::log10(MeV2Hz);
+      Real nu_min = std::pow(10, lnu_min);
+      Real nu_max = std::pow(10, lnu_max);
+
+      constexpr Real lt_min = -1;
+      constexpr Real lt_max = 2;
+      Real dt = (lt_max - lt_min) / (Real)(ntemps - 1);
+
+      Real *nu_bins = (Real *)PORTABLE_MALLOC(nbins * sizeof(Real));
+      Real *lnu_bins = (Real *)PORTABLE_MALLOC(nbins * sizeof(Real));
+      Real *temp_bins = (Real *)PORTABLE_MALLOC(ntemps * sizeof(Real));
+      portableFor(
+          "set nu bins", 0, 1, PORTABLE_LAMBDA(const int &i) {
+            chebyshev::GetPoints(lnu_min, lnu_max, nbins, lnu_bins);
+            for (int j = 0; j < nbins; ++j) {
+              nu_bins[j] = std::pow(10, lnu_bins[j]);
+            }
+          });
+      portableFor(
+          "set temp bins", 0, ntemps, PORTABLE_LAMBDA(const int &i) {
+            temp_bins[i] = std::pow(10, lt_min + dt * i) * MeV2K;
+          });
+
+      Real *vm9 = (Real *)PORTABLE_MALLOC(9 * 9 * sizeof(Real));
+      portableFor(
+          "Fill vm", 0, 1,
+          PORTABLE_LAMBDA(const int &i) { chebyshev::get_vmbox(vm9); });
+
+      portableFor(
+          "Fill the indexers", 0, ntemps, PORTABLE_LAMBDA(const int &i) {
+            Real temp = temp_bins[i];
+
+            Real *nu_data = (Real *)malloc(nbins * sizeof(Real));
+            Real *lnu_data = (Real *)malloc(nbins * sizeof(Real));
+            Real *nu_coeffs = (Real *)malloc(nbins * sizeof(Real));
+            indexers::LogCheb<nbins, Real *> J_cheb(nu_data, lnu_data,
+                                                    nu_coeffs, nu_min, nu_max);
+            opac.EmissivityPerNu(rho, temp, Ye, type, nu_bins, J_cheb, nbins);
+            Real Jtrue = opac.EmissivityPerNu(rho, temp, Ye, type, nu);
+            J_cheb.SetInterpCoeffs(Spiner::DataBox(vm9, 9, 9));
+            if (std::isnan(J_cheb(nu)) ||
+                ((std::abs(Jtrue) >= 1e-14 || J_cheb(nu) >= 1e-14) &&
+                 FractionalDifference(J_cheb(nu), Jtrue) > EPS_TEST)) {
+              n_wrong_d() += 1;
+            }
+            free(nu_data);
+            free(lnu_data);
+            free(nu_coeffs);
+          });
+
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+      Kokkos::deep_copy(n_wrong_h, n_wrong_d);
+#endif
+
+      REQUIRE(n_wrong_h == 0);
+
+      PORTABLE_FREE(vm9);
+      PORTABLE_FREE(nu_bins);
+      PORTABLE_FREE(lnu_bins);
+      PORTABLE_FREE(temp_bins);
+    }
+
+    opac.Finalize();
+  }
+}

--- a/test/test_brt_opacities.cpp
+++ b/test/test_brt_opacities.cpp
@@ -68,7 +68,6 @@ TEST_CASE("BRT neutrino opacities", "[BRTNeutrinos]") {
           "calc emissivities", 0, 100, PORTABLE_LAMBDA(const int &i) {
             Real jnu = opac.EmissivityPerNuOmega(rho, temp, Ye, type, nu);
             Real Jnu = opac.EmissivityPerNu(rho, temp, Ye, type, nu);
-            printf("jnu: %e Jnu: %e\n", jnu, Jnu);
             if (FractionalDifference(Jnu, 4 * M_PI * jnu) > EPS_TEST) {
               n_wrong_d() += 1;
             }
@@ -134,7 +133,7 @@ TEST_CASE("BRT neutrino opacities", "[BRTNeutrinos]") {
       Real nu_min = std::pow(10, lnu_min);
       Real nu_max = std::pow(10, lnu_max);
 
-      constexpr Real lt_min = -1;
+      constexpr Real lt_min = 0;
       constexpr Real lt_max = 2;
       Real dt = (lt_max - lt_min) / (Real)(ntemps - 1);
 

--- a/test/test_brt_opacities.cpp
+++ b/test/test_brt_opacities.cpp
@@ -80,7 +80,7 @@ TEST_CASE("BRT neutrino opacities", "[BRTNeutrinos]") {
       REQUIRE(n_wrong_h == 0);
     }
 
-    WHEN("We create a gray opacity object in non-cgs units") {
+    WHEN("We create a BRT opacity object in non-cgs units") {
       constexpr Real time_unit = 123;
       constexpr Real mass_unit = 456;
       constexpr Real length_unit = 789;

--- a/test/test_brt_opacities.cpp
+++ b/test/test_brt_opacities.cpp
@@ -89,8 +89,9 @@ TEST_CASE("BRT neutrino opacities", "[BRTNeutrinos]") {
           mass_unit / (length_unit * length_unit * length_unit);
       constexpr Real j_unit = mass_unit / (length_unit * time_unit * time_unit);
       neutrinos::Opacity funny_units_host =
-          neutrinos::NonCGSUnits<neutrinos::BRTOpac>(
-              neutrinos::BRTOpac(), time_unit, mass_unit, length_unit, temp_unit);
+          neutrinos::NonCGSUnits<neutrinos::BRTOpac>(neutrinos::BRTOpac(),
+                                                     time_unit, mass_unit,
+                                                     length_unit, temp_unit);
       auto funny_units = funny_units_host.GetOnDevice();
 
       THEN("We can convert meaningfully into and out of funny units") {


### PR DESCRIPTION
Analytic electron neutrino opacity, based on Burrows Reddy Thompson 2004 (some factors ignored), thanks to @lroberts36 for the pointer.

Mostly useful for frequency-dependent tests.