### PR TITLE
Fix thermal distributions again

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,7 @@ singularity-opac
 
 [![Tests](https://github.com/lanl/singularity-opac/actions/workflows/tests.yml/badge.svg)](https://github.com/lanl/singularity-opac/actions/workflows/tests.yml)
 
-Performance Portable Opacity and Emissivity for simulation codes
-
-## Components
-
-- `eos` contains the analytic and tabular equation of state infrastructure
-- `eospac-wrapper` is a wrapper for eospac
-- `closure` contains mixed cell closure models. Currently pressure-temperature equilibrium is supported. Requires `eos`.
-- `sesame2spiner` converts sesame tables to spiner tables
-- `stellarcollaspe2spienr` converts tables found on stellarcollapse.org to spiner tables
+Performance Portable Opacity and Emissivity library for simulation codes
 
 ## API
 
@@ -20,20 +12,25 @@ singularity-opac provides a uniform API for all opacity models. The following fu
 | Function              | Expression | Description            | Units   |
 | --------------------- | ---------- | ---------------------  | ------- |
 | AbsorptionCoefficient | `n \sigma` | Absorption coefficient | `cm^{-1}` |
-| AngleAveragedAbsorptionCoefficient | `\frac{1}{4 \pi}\int d\Omega n \sigma` |Absorption coefficient averaged over solid angle | `cm^{-1}` |
-| EmissivityPerNuOmega | `j_{\nu} = \frac{dE}{d^3x dt d\Omega d\nu}` | Frequency- and angle-dependent emissivity | $erg cm^{-3} s^{-1} Sr^{-1} Hz^{-1}$ |
-| EmissivityPerNu | `\int j_{\nu} d\nu`  | Frequency-dependent emissivity | `erg cm^{-3} s^{-1} Sr^{-1}` |
+| AngleAveragedAbsorptionCoefficient | `\frac{1}{4 \pi}\int n \sigma d\Omega` | Absorption coefficient averaged over solid angle | `cm^{-1}` |
+| EmissivityPerNuOmega | `j_{\nu} = \frac{dE}{d^3x dt d\Omega d\nu}` | Frequency- and angle-dependent emissivity | `erg cm^{-3} s^{-1} Sr^{-1} Hz^{-1}` |
+| EmissivityPerNu | `\int j_{\nu} d\Omega`  | Frequency-dependent emissivity | `erg cm^{-3} s^{-1} Hz^{-1}` |
 | Emissivity | `\int j_{\nu} d\nu d\Omega`  | Total emissivity | `erg cm^{-3} s^{-1}` |
+| NumberEmissivity | `\int \frac{1}{h \nu} j_{\nu} d\Omega d\nu` | Total number emissivity | `cm^{-3} s^{-1}` |
+| ThermalDistributionOfTNu | `B_{\nu} = \frac{dE}{dA dt d\Omega d\nu}` | Specific intensity of thermal distribution | `erg cm^{-2} s^{-1} Sr^{-1} Hz^{-1}` |
+| ThermalDistributionOfT | `B = \int B_{\nu} d\Omega d\nu` | Frequency- and angle-integrated intensity of thermal distribution | `erg cm^{-2} s^{-1}` |
+| ThermalNumberDistributionOfT | `B = \int \frac{1}{h \nu} B_{\nu} d\Omega d\nu` | Frequency- and angle-integrated intensity of thermal distribution | `erg cm^{-2} s^{-1}` |
 
-Note that the thermal radiation energy density `u = 1/c ThermalDistributionOfT` and the thermal radiation number density `n = 1/c ThermalNumberDistribution`.
+Note that the thermal radiation energy density `u = 1/c ThermalDistributionOfT` and the thermal radiation number density `n = 1/c ThermalNumberDistributionOfT`.
 
+Internally singularity-opac always uses CGS units, as in the above table. However, arbitrary units are supported through the units modifier.
 
 ## To Build
 
 At its most basic:
 ```bash
-git clone --recursive git@github.com:lanl/singularity-eos.git
-cd singularity-eos
+git clone --recursive git@github.com:lanl/singularity-opac.git
+cd singularity-opac
 mkdir bin
 cd bin
 cmake ..
@@ -42,7 +39,7 @@ make
 
 ### To Make tests
 
-Then, in the singularity-eos root directory:
+Then, in the singularity-opac root directory:
 ```bash
 mkdir -p bin
 cd bin
@@ -58,21 +55,6 @@ A number of options are avaialable for compiling:
 | Option                            | Default | Comment                                                                              |
 | --------------------------------- | ------- | ------------------------------------------------------------------------------------ |
 | SINGULARITY_BUILD_TESTS           | OFF     | Build test infrastructure.                                                           |
-
-## Units
-
-singularity-eos, prior to unit modifiers, always uses CGS units internally. For
-concreteness, the internal units of each quantity are:
-
-| Quantity                  | Alternate names      | Units         |
-| ------------------------- | -------------------- | ------------- |
-| Mass density              | rho                  | g cm^-3       |
-| Temperature               | temperature          | K             |
-| Specific Internal Energy  | sie, Internal Energy | erg g^-1      |
-| Pressure                  |                      | erg cm^-3     |
-| Specific Heat             |                      | erg g^-1 K^-1 |
-| Bulk Modulus              |                      | erg cm^-3     |
-| Gruneisen Parameter       |                      |               |
 
 ## Copyright
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,84 @@ singularity-opac
 
 Performance Portable Opacity and Emissivity for simulation codes
 
+## Components
+
+- `eos` contains the analytic and tabular equation of state infrastructure
+- `eospac-wrapper` is a wrapper for eospac
+- `closure` contains mixed cell closure models. Currently pressure-temperature equilibrium is supported. Requires `eos`.
+- `sesame2spiner` converts sesame tables to spiner tables
+- `stellarcollaspe2spienr` converts tables found on stellarcollapse.org to spiner tables
+
+## API
+
+singularity-opac provides a uniform API for all opacity models. The following functions are provided
+(here, $\sigma$ is the frequency- and angle-dependent cross section in units of $cm^2$):
+| Function              | Expression | Description            | Units   |
+| --------------------- | ---------- | ---------------------  | ------- |
+| AbsorptionCoefficient | $n \sigma$ | Absorption coefficient | $cm^-1$ |
+
+
+## To Build
+
+At its most basic:
+```bash
+git clone --recursive git@github.com:lanl/singularity-eos.git
+cd singularity-eos
+mkdir bin
+cd bin
+cmake ..
+make
+```
+
+### To Make tests
+
+Then, in the singularity-eos root directory:
+```bash
+mkdir -p bin
+cd bin
+cmake -DSINGULARITY_BUILD_TESTS=ON ..
+make -j
+make test
+```
+
+### Build Options
+
+A number of options are avaialable for compiling:
+
+| Option                            | Default | Comment                                                                              |
+| --------------------------------- | ------- | ------------------------------------------------------------------------------------ |
+| SINGULARITY_USE_HDF5              | ON      | Enables HDF5. Required for SpinerEOS, StellarCollapseEOS, and sesame2spiner          |
+| SINGULARITY_USE_FORTRAN           | ON      | Enable Fortran API for equation of state                                             |
+| SINGULARITY_USE_KOKKOS            | OFF     | Uses Kokkos as the portability backend. Currently only Kokkos is supported for GPUs. |
+| SINGULARITY_USE_EOSPAC            | OFF     | Link against EOSPAC. Needed for sesame2spiner and some tests.                        |
+| SINGULARITY_USE_CUDA              | OFF     | Target nvidia GPUs via cuda. Currently requires Kokkos.                              |
+| SINGULARITY_USE_KOKKOSKERNELS     | OFF     | Use Kokkos Kernels for linear algebra. Needed for mixed cell closure models on GPU   |
+| SINGULARITY_BUILD_CLOSURE         | ON      | Builds mixed cell closure machinery for multi-material problems                      |
+| SINGULARITY_BUILD_TESTS           | OFF     | Build test infrastructure.                                                           |
+| SINGULARITY_TEST_SESAME           | OFF     | Test the Sesame table readers                                                        |
+| SINGULARITY_TEST_STELLAR_COLLAPSE | OFF     | Test the Stellar Collapse table readers                                              |
+| SINGULARITY_BUILD_SESAME2SPINER   | OFF     | Builds the conversion tool sesame2spiner which makes files readable by SpinerEOS     |
+| SINGULARITY_BUILD_STELLARCOLLAPSE2SPINER | OFF     | Builds the conversion tool stellarcollapse2spiner which optionally makes stellar collapse files faster to read |
+| SINGULARITY_INVERT_AT_SETUP       | OFF     | For tests, pre-invert eospac tables.                                                 |
+| SINGULARITY_BETTER_DEBUG_FLAGS    | ON      | Enables nicer GPU debug flags. May interfere with in-tree builds as a submodule      |
+| SINGULARITY_HIDE_MORE_WARNINGS    | OFF     | Makes warnings less verbose. May interfere with in-tree builds as a submodule        |
+| SINGULARITY_SUBMODULE_MODE        | OFF     | Sets cmake flags for in-tree builds                                                  |
+
+## Units
+
+singularity-eos, prior to unit modifiers, always uses CGS units internally. For
+concreteness, the internal units of each quantity are:
+
+| Quantity                  | Alternate names      | Units         |
+| ------------------------- | -------------------- | ------------- |
+| Mass density              | rho                  | g cm^-3       |
+| Temperature               | temperature          | K             |
+| Specific Internal Energy  | sie, Internal Energy | erg g^-1      |
+| Pressure                  |                      | erg cm^-3     |
+| Specific Heat             |                      | erg g^-1 K^-1 |
+| Bulk Modulus              |                      | erg cm^-3     |
+| Gruneisen Parameter       |                      |               |
+
 ## Copyright
 
 © 2021. Triad National Security, LLC. All rights reserved.  This

--- a/README.md
+++ b/README.md
@@ -16,10 +16,16 @@ Performance Portable Opacity and Emissivity for simulation codes
 ## API
 
 singularity-opac provides a uniform API for all opacity models. The following functions are provided
-(here, $\sigma$ is the frequency- and angle-dependent cross section in units of $cm^2$):
+(here, `\sigma` is the frequency- and angle-dependent cross section in units of `cm^2`):
 | Function              | Expression | Description            | Units   |
 | --------------------- | ---------- | ---------------------  | ------- |
-| AbsorptionCoefficient | $n \sigma$ | Absorption coefficient | $cm^-1$ |
+| AbsorptionCoefficient | `n \sigma` | Absorption coefficient | `cm^{-1}` |
+| AngleAveragedAbsorptionCoefficient | `\frac{1}{4 \pi}\int d\Omega n \sigma` |Absorption coefficient averaged over solid angle | `cm^{-1}` |
+| EmissivityPerNuOmega | `j_{\nu} = \frac{dE}{d^3x dt d\Omega d\nu}` | Frequency- and angle-dependent emissivity | $erg cm^{-3} s^{-1} Sr^{-1} Hz^{-1}$ |
+| EmissivityPerNu | `\int j_{\nu} d\nu`  | Frequency-dependent emissivity | `erg cm^{-3} s^{-1} Sr^{-1}` |
+| Emissivity | `\int j_{\nu} d\nu d\Omega`  | Total emissivity | `erg cm^{-3} s^{-1}` |
+
+Note that the thermal radiation energy density `u = 1/c ThermalDistributionOfT` and the thermal radiation number density `n = 1/c ThermalNumberDistribution`.
 
 
 ## To Build
@@ -51,22 +57,7 @@ A number of options are avaialable for compiling:
 
 | Option                            | Default | Comment                                                                              |
 | --------------------------------- | ------- | ------------------------------------------------------------------------------------ |
-| SINGULARITY_USE_HDF5              | ON      | Enables HDF5. Required for SpinerEOS, StellarCollapseEOS, and sesame2spiner          |
-| SINGULARITY_USE_FORTRAN           | ON      | Enable Fortran API for equation of state                                             |
-| SINGULARITY_USE_KOKKOS            | OFF     | Uses Kokkos as the portability backend. Currently only Kokkos is supported for GPUs. |
-| SINGULARITY_USE_EOSPAC            | OFF     | Link against EOSPAC. Needed for sesame2spiner and some tests.                        |
-| SINGULARITY_USE_CUDA              | OFF     | Target nvidia GPUs via cuda. Currently requires Kokkos.                              |
-| SINGULARITY_USE_KOKKOSKERNELS     | OFF     | Use Kokkos Kernels for linear algebra. Needed for mixed cell closure models on GPU   |
-| SINGULARITY_BUILD_CLOSURE         | ON      | Builds mixed cell closure machinery for multi-material problems                      |
 | SINGULARITY_BUILD_TESTS           | OFF     | Build test infrastructure.                                                           |
-| SINGULARITY_TEST_SESAME           | OFF     | Test the Sesame table readers                                                        |
-| SINGULARITY_TEST_STELLAR_COLLAPSE | OFF     | Test the Stellar Collapse table readers                                              |
-| SINGULARITY_BUILD_SESAME2SPINER   | OFF     | Builds the conversion tool sesame2spiner which makes files readable by SpinerEOS     |
-| SINGULARITY_BUILD_STELLARCOLLAPSE2SPINER | OFF     | Builds the conversion tool stellarcollapse2spiner which optionally makes stellar collapse files faster to read |
-| SINGULARITY_INVERT_AT_SETUP       | OFF     | For tests, pre-invert eospac tables.                                                 |
-| SINGULARITY_BETTER_DEBUG_FLAGS    | ON      | Enables nicer GPU debug flags. May interfere with in-tree builds as a submodule      |
-| SINGULARITY_HIDE_MORE_WARNINGS    | OFF     | Makes warnings less verbose. May interfere with in-tree builds as a submodule        |
-| SINGULARITY_SUBMODULE_MODE        | OFF     | Sets cmake flags for in-tree builds                                                  |
 
 ## Units
 

--- a/singularity-opac/neutrinos/gray_opacity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/gray_opacity_neutrinos.hpp
@@ -128,8 +128,7 @@ class GrayOpacity {
   PORTABLE_INLINE_FUNCTION
   Real NumberEmissivity(const Real rho, const Real temp, Real Ye,
                         RadiationType type, Real *lambda = nullptr) const {
-    return kappa_ *
-           dist_.ThermalNumberDistribution(temp, type, lambda);
+    return kappa_ * dist_.ThermalNumberDistributionOfT(temp, type, lambda);
   }
 
   PORTABLE_INLINE_FUNCTION

--- a/singularity-opac/neutrinos/gray_opacity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/gray_opacity_neutrinos.hpp
@@ -122,13 +122,13 @@ class GrayOpacity {
   Real Emissivity(const Real rho, const Real temp, const Real Ye,
                   const RadiationType type, Real *lambda = nullptr) const {
     Real B = dist_.ThermalDistributionOfT(temp, type, lambda);
-    return 4 * M_PI * rho * kappa_ * B;
+    return rho * kappa_ * B;
   }
 
   PORTABLE_INLINE_FUNCTION
   Real NumberEmissivity(const Real rho, const Real temp, Real Ye,
                         RadiationType type, Real *lambda = nullptr) const {
-    return 4 * M_PI * kappa_ *
+    return kappa_ *
            dist_.ThermalNumberDistribution(temp, type, lambda);
   }
 
@@ -144,9 +144,9 @@ class GrayOpacity {
     return dist_.ThermalDistributionOfT(temp, type, lambda);
   }
 
-  PORTABLE_INLINE_FUNCTION Real ThermalNumberDistribution(
+  PORTABLE_INLINE_FUNCTION Real ThermalNumberDistributionOfT(
       const Real temp, const RadiationType type, Real *lambda = nullptr) const {
-    return dist_.ThermalNumberDistribution(temp, type, lambda);
+    return dist_.ThermalNumberDistributionOfT(temp, type, lambda);
   }
 
  private:

--- a/singularity-opac/neutrinos/neutrino_variant.hpp
+++ b/singularity-opac/neutrinos/neutrino_variant.hpp
@@ -225,11 +225,11 @@ class Variant {
   }
 
   // Number density of thermal distribution
-  PORTABLE_INLINE_FUNCTION Real ThermalNumberDistribution(
+  PORTABLE_INLINE_FUNCTION Real ThermalNumberDistributionOfT(
       const Real temp, const RadiationType type, Real *lambda = nullptr) const {
     return mpark::visit(
         [=](const auto &opac) {
-          return opac.ThermalNumberDistribution(temp, type, lambda);
+          return opac.ThermalNumberDistributionOfT(temp, type, lambda);
         },
         opac_);
   }

--- a/singularity-opac/neutrinos/non_cgs_neutrinos.hpp
+++ b/singularity-opac/neutrinos/non_cgs_neutrinos.hpp
@@ -196,7 +196,7 @@ class NonCGSUnits {
 
   PORTABLE_INLINE_FUNCTION
   Real ThermalNumberDistributionOfT(const Real temp, const RadiationType type,
-                                 Real *lambda = nullptr) const {
+                                    Real *lambda = nullptr) const {
     Real NoH = opac_.ThermalNumberDistributionOfT(temp, type, lambda);
     return NoH * mass_unit_ / rho_unit_;
   }

--- a/singularity-opac/neutrinos/non_cgs_neutrinos.hpp
+++ b/singularity-opac/neutrinos/non_cgs_neutrinos.hpp
@@ -195,9 +195,9 @@ class NonCGSUnits {
   }
 
   PORTABLE_INLINE_FUNCTION
-  Real ThermalNumberDistribution(const Real temp, const RadiationType type,
+  Real ThermalNumberDistributionOfT(const Real temp, const RadiationType type,
                                  Real *lambda = nullptr) const {
-    Real NoH = opac_.ThermalNumberDistribution(temp, type, lambda);
+    Real NoH = opac_.ThermalNumberDistributionOfT(temp, type, lambda);
     return NoH * mass_unit_ / rho_unit_;
   }
 

--- a/singularity-opac/neutrinos/spiner_opac_neutrinos.hpp
+++ b/singularity-opac/neutrinos/spiner_opac_neutrinos.hpp
@@ -40,12 +40,6 @@
 // JMM: Doing everything in log-log, because everything should be
 // positive and should roughly follow a power law actually.
 
-// TODO(JMM): Should the table be tabulated in frequencies or MeV?
-// MeV probably makes more sense, even if the host code uses
-// frequencies.
-// Same goes for temperatures: Kelvin or MeV? I lean towards Kelvin
-// fairly arbitrarily.
-
 // TODO(JMM): The dynamic range in the mantissa is too large, so we
 // can't use log10 for floats and take advantage of that performance
 // enhancement, unfortunately.
@@ -336,9 +330,9 @@ class SpinerOpacity {
     return dist_.ThermalDistributionOfT(temp, type, lambda);
   }
 
-  PORTABLE_INLINE_FUNCTION Real ThermalNumberDistribution(
+  PORTABLE_INLINE_FUNCTION Real ThermalNumberDistributionOfT(
       const Real temp, const RadiationType type, Real *lambda = nullptr) const {
-    return dist_.ThermalNumberDistribution(temp, type, lambda);
+    return dist_.ThermalNumberDistributionOfT(temp, type, lambda);
   }
 
  private:

--- a/singularity-opac/neutrinos/thermal_distributions_neutrinos.hpp
+++ b/singularity-opac/neutrinos/thermal_distributions_neutrinos.hpp
@@ -43,14 +43,14 @@ struct FermiDiracDistributionNoMu {
   Real ThermalDistributionOfT(const Real temp, const RadiationType type,
                               Real *lambda = nullptr) const {
     return 7. * std::pow(M_PI, 5) * std::pow(pc::kb, 4) * NSPECIES *
-           std::pow(temp, 4) / (15. * std::pow(pc::c, 3) * std::pow(pc::h, 3));
+           std::pow(temp, 4) / (15. * std::pow(pc::c, 2) * std::pow(pc::h, 3));
   }
   PORTABLE_INLINE_FUNCTION
-  Real ThermalNumberDistribution(const Real temp, const RadiationType type,
+  Real ThermalNumberDistributionOfT(const Real temp, const RadiationType type,
                                  Real *lambda = nullptr) const {
     constexpr Real zeta3 = 1.20206;
-    return 16. * pow(pc::kb, 3) * M_PI * NSPECIES * pow(temp, 3) * zeta3 /
-           (pow(pc::c, 3) * pow(pc::h, 3));
+    return 12. * pow(pc::kb, 3) * M_PI * NSPECIES * pow(temp, 3) * zeta3 /
+           (pow(pc::c, 2) * pow(pc::h, 3));
   }
   template <typename Emissivity>
   PORTABLE_INLINE_FUNCTION Real AbsorptionCoefficientFromKirkhoff(

--- a/singularity-opac/neutrinos/thermal_distributions_neutrinos.hpp
+++ b/singularity-opac/neutrinos/thermal_distributions_neutrinos.hpp
@@ -47,7 +47,7 @@ struct FermiDiracDistributionNoMu {
   }
   PORTABLE_INLINE_FUNCTION
   Real ThermalNumberDistributionOfT(const Real temp, const RadiationType type,
-                                 Real *lambda = nullptr) const {
+                                    Real *lambda = nullptr) const {
     constexpr Real zeta3 = 1.20206;
     return 12. * pow(pc::kb, 3) * M_PI * NSPECIES * pow(temp, 3) * zeta3 /
            (pow(pc::c, 2) * pow(pc::h, 3));

--- a/singularity-opac/neutrinos/tophat_emissivity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/tophat_emissivity_neutrinos.hpp
@@ -160,9 +160,9 @@ class TophatEmissivity {
     return dist_.ThermalDistributionOfT(temp, type, lambda);
   }
 
-  PORTABLE_INLINE_FUNCTION Real ThermalNumberDistribution(
+  PORTABLE_INLINE_FUNCTION Real ThermalNumberDistributionOfT(
       const Real temp, const RadiationType type, Real *lambda = nullptr) const {
-    return dist_.ThermalNumberDistribution(temp, type, lambda);
+    return dist_.ThermalNumberDistributionOfT(temp, type, lambda);
   }
 
  private:

--- a/singularity-opac/photons/gray_opacity_photons.hpp
+++ b/singularity-opac/photons/gray_opacity_photons.hpp
@@ -120,7 +120,7 @@ class GrayOpacity {
   PORTABLE_INLINE_FUNCTION
   Real NumberEmissivity(const Real rho, const Real temp,
                         Real *lambda = nullptr) const {
-    return kappa_ * dist_.ThermalNumberDistribution(temp, lambda);
+    return kappa_ * dist_.ThermalNumberDistributionOfT(temp, lambda);
   }
 
   PORTABLE_INLINE_FUNCTION
@@ -135,8 +135,8 @@ class GrayOpacity {
   }
 
   PORTABLE_INLINE_FUNCTION Real
-  ThermalNumberDistribution(const Real temp, Real *lambda = nullptr) const {
-    return dist_.ThermalNumberDistribution(temp, lambda);
+  ThermalNumberDistributionOfT(const Real temp, Real *lambda = nullptr) const {
+    return dist_.ThermalNumberDistributionOfT(temp, lambda);
   }
 
  private:

--- a/singularity-opac/photons/non_cgs_photons.hpp
+++ b/singularity-opac/photons/non_cgs_photons.hpp
@@ -181,7 +181,7 @@ class NonCGSUnits {
 
   PORTABLE_INLINE_FUNCTION
   Real ThermalNumberDistributionOfT(const Real temp,
-                                 Real *lambda = nullptr) const {
+                                    Real *lambda = nullptr) const {
     Real NoH = opac_.ThermalNumberDistributionOfT(temp, lambda);
     return NoH * mass_unit_ / rho_unit_;
   }

--- a/singularity-opac/photons/non_cgs_photons.hpp
+++ b/singularity-opac/photons/non_cgs_photons.hpp
@@ -180,9 +180,9 @@ class NonCGSUnits {
   }
 
   PORTABLE_INLINE_FUNCTION
-  Real ThermalNumberDistribution(const Real temp,
+  Real ThermalNumberDistributionOfT(const Real temp,
                                  Real *lambda = nullptr) const {
-    Real NoH = opac_.ThermalNumberDistribution(temp, lambda);
+    Real NoH = opac_.ThermalNumberDistributionOfT(temp, lambda);
     return NoH * mass_unit_ / rho_unit_;
   }
 

--- a/singularity-opac/photons/photon_variant.hpp
+++ b/singularity-opac/photons/photon_variant.hpp
@@ -212,10 +212,10 @@ class Variant {
 
   // Number density of thermal distribution
   PORTABLE_INLINE_FUNCTION Real
-  ThermalNumberDistribution(const Real temp, Real *lambda = nullptr) const {
+  ThermalNumberDistributionOfT(const Real temp, Real *lambda = nullptr) const {
     return mpark::visit(
         [=](const auto &opac) {
-          return opac.ThermalNumberDistribution(temp, lambda);
+          return opac.ThermalNumberDistributionOfT(temp, lambda);
         },
         opac_);
   }

--- a/singularity-opac/photons/thermal_distributions_photons.hpp
+++ b/singularity-opac/photons/thermal_distributions_photons.hpp
@@ -43,7 +43,7 @@ struct PlanckDistribution {
   }
   PORTABLE_INLINE_FUNCTION
   Real ThermalNumberDistributionOfT(const Real temp,
-                                 Real *lambda = nullptr) const {
+                                    Real *lambda = nullptr) const {
     constexpr Real zeta3 = 1.20206;
     return 16. * pow(pc::kb, 3) * M_PI * pow(temp, 3) * zeta3 /
            (pow(pc::c, 2) * pow(pc::h, 3));

--- a/singularity-opac/photons/thermal_distributions_photons.hpp
+++ b/singularity-opac/photons/thermal_distributions_photons.hpp
@@ -39,14 +39,14 @@ struct PlanckDistribution {
   PORTABLE_INLINE_FUNCTION
   Real ThermalDistributionOfT(const Real temp, Real *lambda = nullptr) const {
     return 8. * std::pow(M_PI, 5) * std::pow(pc::kb, 4) * std::pow(temp, 4) /
-           (15. * std::pow(pc::c, 3) * std::pow(pc::h, 3));
+           (15. * std::pow(pc::c, 2) * std::pow(pc::h, 3));
   }
   PORTABLE_INLINE_FUNCTION
-  Real ThermalNumberDistribution(const Real temp,
+  Real ThermalNumberDistributionOfT(const Real temp,
                                  Real *lambda = nullptr) const {
     constexpr Real zeta3 = 1.20206;
     return 16. * pow(pc::kb, 3) * M_PI * pow(temp, 3) * zeta3 /
-           (pow(pc::c, 3) * pow(pc::h, 3));
+           (pow(pc::c, 2) * pow(pc::h, 3));
   }
   template <typename Emissivity>
   PORTABLE_INLINE_FUNCTION Real AbsorptionCoefficientFromKirkhoff(


### PR DESCRIPTION
I misunderstood what `ThermalDistributionOfT` was providing (and so I broke e.g. gray opacities in #20).

I also changed `ThermalNumberDistribution` to `ThermalNumberDistributionOfT` for symmetry.

Ultimately we want to provide both `I = \int I_{\nu} d\Omega d\nu` and `u = 1/c \int I_{\nu} d\Omega d\nu`. However, this is always just division by `c` so long as the particles are always moving at `c`. So let's not add the extra functions. I included a note in the `README` about this conversion.

I'm also adding to `README.md` to help avoid this kind of confusion going forward