### PR TITLE
Add Planck and Rosseland means

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,11 +19,11 @@ jobs:
         - name: Set system to non-interactive mode
           run: export DEBIAN_FRONTEND=noninteractive
         - name: install dependencies
-          run: sudo apt-get install -y --force-yes -qq build-essential
+          run: sudo apt-get install -y --force-yes -qq build-essential libhdf5-serial-dev
         - name: build and run tests
           run: |
             mkdir -p bin
             cd bin
-            cmake -DSINGULARITY_BUILD_TESTS=ON ..
+            cmake -DSINGULARITY_BUILD_TESTS=ON -DSINGULARITY_USE_HDF5=ON ..
             make -j
             make test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,6 @@ endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS On)
 
-
 # Patches variant to be compatible with cuda
 # Assumes "patch" is present on system
 message(STATUS "Patching mpark::variant to support GPUs")

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Then, in the singularity-opac root directory:
 mkdir -p bin
 cd bin
 cmake -DSINGULARITY_BUILD_TESTS=ON ..
+cmake -DSINGULARITY_BUILD_TESTS=ON -DSINGULARITY_USE_HDF5=ON -DCMAKE_CXX_COMPILER=mpicxx ..
 make -j
 make test
 ```

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ singularity-opac provides a uniform API for all opacity models. The following fu
 | Emissivity | `\int j_{\nu} d\nu d\Omega`  | Total emissivity | `erg cm^{-3} s^{-1}` |
 | NumberEmissivity | `\int \frac{1}{h \nu} j_{\nu} d\Omega d\nu` | Total number emissivity | `cm^{-3} s^{-1}` |
 | ThermalDistributionOfTNu | `B_{\nu} = \frac{dE}{dA dt d\Omega d\nu}` | Specific intensity of thermal distribution | `erg cm^{-2} s^{-1} Sr^{-1} Hz^{-1}` |
+| DThermalDistributionOfTNuDT | `dB_{\nu}/dT` | Temperature derivative of specific intensity of thermal distribution | `erg cm^{-2} s^{-1} Sr^{-1} Hz^{-1} K^{-1}` |
 | ThermalDistributionOfT | `B = \int B_{\nu} d\Omega d\nu` | Frequency- and angle-integrated intensity of thermal distribution | `erg cm^{-2} s^{-1}` |
 | ThermalNumberDistributionOfT | `B = \int \frac{1}{h \nu} B_{\nu} d\Omega d\nu` | Frequency- and angle-integrated intensity of thermal distribution | `erg cm^{-2} s^{-1}` |
 

--- a/cmake/SetupDeps.cmake
+++ b/cmake/SetupDeps.cmake
@@ -48,11 +48,11 @@ if (HDF5_FOUND)
     )
 
     # if HDF5 is parallel, also get MPI libraries
-    if (HDF5_IS_PARALELL)
+    if (HDF5_IS_PARALLEL)
       message(status "Parallel HDF5 found. Looking for MPI")
       # Provides MPI::MPI_CXX
       if (NOT TARGET MPI::MPI_CXX)
-	find_package(MPI COMPONENTS CXX REQUIRED)
+	find_package(MPI COMPONENTS)# CXX REQUIRED)
 	if (NOT MPI_FOUND)
 	  message(FATAL_ERROR
 	    "HDF5 parallel found, but could not find MPI! "

--- a/singularity-opac/base/sp5.hpp
+++ b/singularity-opac/base/sp5.hpp
@@ -18,15 +18,21 @@
 
 namespace SP5 {
 
-  namespace Opac {
-    constexpr char defaultFileName[] = "opac.sp5";
-    constexpr char AbsorptionCoefficient[] = "absorption coefficient";
-    constexpr char AngleAveragedAbsorptionCoefficient[] = "angle-averaged absorption coefficient";
-    constexpr char EmissivityPerNu[] = "emissivity per nu";
-    constexpr char TotalEmissivity[] = "total emissivity";
-    constexpr char NumberEmissivity[] = "number emissivity";
-  }
+namespace Opac {
+constexpr char defaultFileName[] = "opac.sp5";
+constexpr char AbsorptionCoefficient[] = "absorption coefficient";
+constexpr char AngleAveragedAbsorptionCoefficient[] =
+    "angle-averaged absorption coefficient";
+constexpr char EmissivityPerNu[] = "emissivity per nu";
+constexpr char TotalEmissivity[] = "total emissivity";
+constexpr char NumberEmissivity[] = "number emissivity";
+} // namespace Opac
 
-}
+namespace MeanOpac {
+constexpr char PlanckMeanOpacity[] = "Planck mean opacity";
+constexpr char RosselandMeanOpacity[] = "Rosseland mean opacity";
+} // namespace MeanOpac
+
+} // namespace SP5
 
 #endif // SINGULARITY_OPAC_BASE_SP5_

--- a/singularity-opac/neutrinos/brt_neutrinos.hpp
+++ b/singularity-opac/neutrinos/brt_neutrinos.hpp
@@ -61,6 +61,21 @@ class BRTOpacity {
   }
 
   PORTABLE_INLINE_FUNCTION
+  Real PlanckMeanAbsorptionCoefficient(const Real rho, const Real temp,
+                                       const Real Ye, const RadiationType type,
+                                       Real *lambda = nullptr) const {
+    OPAC_ERROR("Planck mean currently not implemented for BRT!");
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real RosselandMeanAbsorptionCoefficient(const Real rho, const Real temp,
+                                          const Real Ye,
+                                          const RadiationType type,
+                                          Real *lambda = nullptr) const {
+    OPAC_ERROR("Rosseland mean currently not implemented for BRT!");
+  }
+
+  PORTABLE_INLINE_FUNCTION
   Real AngleAveragedAbsorptionCoefficient(const Real rho, const Real temp,
                                           const Real Ye,
                                           const RadiationType type,

--- a/singularity-opac/neutrinos/brt_neutrinos.hpp
+++ b/singularity-opac/neutrinos/brt_neutrinos.hpp
@@ -61,21 +61,6 @@ class BRTOpacity {
   }
 
   PORTABLE_INLINE_FUNCTION
-  Real PlanckMeanAbsorptionCoefficient(const Real rho, const Real temp,
-                                       const Real Ye, const RadiationType type,
-                                       Real *lambda = nullptr) const {
-    OPAC_ERROR("Planck mean currently not implemented for BRT!");
-  }
-
-  PORTABLE_INLINE_FUNCTION
-  Real RosselandMeanAbsorptionCoefficient(const Real rho, const Real temp,
-                                          const Real Ye,
-                                          const RadiationType type,
-                                          Real *lambda = nullptr) const {
-    OPAC_ERROR("Rosseland mean currently not implemented for BRT!");
-  }
-
-  PORTABLE_INLINE_FUNCTION
   Real AngleAveragedAbsorptionCoefficient(const Real rho, const Real temp,
                                           const Real Ye,
                                           const RadiationType type,

--- a/singularity-opac/neutrinos/brt_neutrinos.hpp
+++ b/singularity-opac/neutrinos/brt_neutrinos.hpp
@@ -150,6 +150,13 @@ class BRTOpacity {
   }
 
   PORTABLE_INLINE_FUNCTION
+  Real DThermalDistributionOfTNuDT(const Real temp, const RadiationType type,
+                                   const Real nu,
+                                   Real *lambda = nullptr) const {
+    return dist_.DThermalDistributionOfTNuDT(temp, type, nu, lambda);
+  }
+
+  PORTABLE_INLINE_FUNCTION
   Real ThermalDistributionOfT(const Real temp, const RadiationType type,
                               Real *lambda = nullptr) const {
     return dist_.ThermalDistributionOfT(temp, type, lambda);

--- a/singularity-opac/neutrinos/gray_opacity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/gray_opacity_neutrinos.hpp
@@ -71,6 +71,21 @@ class GrayOpacity {
     return rho * kappa_;
   }
 
+  PORTABLE_INLINE_FUNCTION
+  Real PlanckMeanAbsorptionCoefficient(const Real rho, const Real temp,
+                                       const Real Ye, const RadiationType type,
+                                       Real *lambda = nullptr) const {
+    return rho * kappa_;
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real RosselandMeanAbsorptionCoefficient(const Real rho, const Real temp,
+                                          const Real Ye,
+                                          const RadiationType type,
+                                          Real *lambda = nullptr) const {
+    return rho * kappa_;
+  }
+
   template <typename FrequencyIndexer, typename DataIndexer>
   PORTABLE_INLINE_FUNCTION void AngleAveragedAbsorptionCoefficient(
       const Real rho, const Real temp, const Real Ye, const RadiationType type,

--- a/singularity-opac/neutrinos/gray_opacity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/gray_opacity_neutrinos.hpp
@@ -71,21 +71,6 @@ class GrayOpacity {
     return rho * kappa_;
   }
 
-  PORTABLE_INLINE_FUNCTION
-  Real PlanckMeanAbsorptionCoefficient(const Real rho, const Real temp,
-                                       const Real Ye, const RadiationType type,
-                                       Real *lambda = nullptr) const {
-    return rho * kappa_;
-  }
-
-  PORTABLE_INLINE_FUNCTION
-  Real RosselandMeanAbsorptionCoefficient(const Real rho, const Real temp,
-                                          const Real Ye,
-                                          const RadiationType type,
-                                          Real *lambda = nullptr) const {
-    return rho * kappa_;
-  }
-
   template <typename FrequencyIndexer, typename DataIndexer>
   PORTABLE_INLINE_FUNCTION void AngleAveragedAbsorptionCoefficient(
       const Real rho, const Real temp, const Real Ye, const RadiationType type,

--- a/singularity-opac/neutrinos/gray_opacity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/gray_opacity_neutrinos.hpp
@@ -153,6 +153,13 @@ class GrayOpacity {
   }
 
   PORTABLE_INLINE_FUNCTION
+  Real DThermalDistributionOfTNuDT(const Real temp, const RadiationType type,
+                                   const Real nu,
+                                   Real *lambda = nullptr) const {
+    return dist_.DThermalDistributionOfTNuDT(temp, type, nu, lambda);
+  }
+
+  PORTABLE_INLINE_FUNCTION
   Real ThermalDistributionOfT(const Real temp, const RadiationType type,
                               Real *lambda = nullptr) const {
     return dist_.ThermalDistributionOfT(temp, type, lambda);

--- a/singularity-opac/neutrinos/mean_opacity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/mean_opacity_neutrinos.hpp
@@ -1,0 +1,141 @@
+// ======================================================================
+// © 2022. Triad National Security, LLC. All rights reserved.  This
+// program was produced under U.S. Government contract
+// 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
+// is operated by Triad National Security, LLC for the U.S.
+// Department of Energy/National Nuclear Security Administration. All
+// rights in the program are reserved by Triad National Security, LLC,
+// and the U.S. Department of Energy/National Nuclear Security
+// Administration. The Government is granted for itself and others
+// acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works,
+// distribute copies to the public, perform publicly and display
+// publicly, and to permit others to do so.
+// ======================================================================
+
+#ifndef SINGULARITY_OPAC_NEUTRINOS_MEAN_OPACITY_NEUTRINOS_
+#define SINGULARITY_OPAC_NEUTRINOS_MEAN_OPACITY_NEUTRINOS_
+
+#include <cmath>
+
+#include <ports-of-call/portability.hpp>
+#include <singularity-opac/base/radiation_types.hpp>
+#include <singularity-opac/constants/constants.hpp>
+
+namespace singularity {
+namespace neutrinos {
+
+using pc = PhysicalConstants<CGS>;
+
+#define EPS (10.0 * std::numeric_limits<Real>::min())
+
+// TODO(BRR) Note: It is assumed that lambda is constant for all densities,
+// temperatures, and Ye
+
+class MeanOpacity {
+ public:
+  MeanOpacity() = default;
+  MeanOpacity(const Opacity &opac, Real lRhoMin, Real lRhoMax, int NRho,
+              Real lTMin, Real lTMax, int NT, Real YeMin, Real YeMax, int NYe,
+              Real *lambda = nullptr) {
+    lkappaPlanck_.resize(NRho, NT, NYe, NEUTRINO_NTYPES);
+    // index 0 is the species and is not interpolatable
+    lkappaPlanck_.setRange(1, YeMin, YeMax, NYe);
+    lkappaPlanck_.setRange(2, lTMin, lTMax, NT);
+    lkappaPlanck_.setRange(3, lRhoMin, lRhoMax, NRho);
+    lkappaRosseland_.copyMetadata(lkappaPlanck_);
+
+    // Fill tables
+    for (int iRho = 0; iRho < NRho; ++iRho) {
+      Real lRho = lkappaPlanck_.range(3).x(iRho);
+      Real rho = fromLog_(lRho);
+      for (int iT = 0; iT < NT; ++iT) {
+        Real lT = lkappaPlanck_.range(2).x(iT);
+        Real T = fromLog_(lT);
+        for (int iYe = 0; iYe < NYe; ++iYe) {
+          Real Ye = lkappaPlanck_.range(1).x(iYe);
+          for (int idx = 0; idx < NEUTRINO_NTYPES; ++idx) {
+            RadiationType type = Idx2RadType(idx);
+            Real kappaPlanckNum = 0.;
+            Real kappaPlanckDenom = 0.;
+            Real kappaRosselandNum = 0.;
+            Real kappaRosselandDenom = 0.;
+            // Integrate over frequency
+            const int nnu = 100;
+            const Real lnuMin = toLog_(1.e10);
+            const Real lnuMax = toLog_(1.e30);
+            const Real dlnu = (lnuMax - lnuMin) / (nnu - 1);
+            for (int inu = 0; inu < nnu; ++inu) {
+              const Real lnu = lnuMin + inu * dlnu;
+              const Real nu = fromLog_(lnu);
+              kappaPlanckNum +=
+                  opac.AbsorptionCoefficient(rho, T, Ye, type, nu, lambda) /
+                  rho * opac.ThermalDistributionOfTNu(T, type, nu) * nu * dlnu;
+              kappaPlanckDenom +=
+                  opac.ThermalDistributionOfTNu(T, type, nu) * nu * dlnu;
+
+              kappaRosselandNum +=
+                  rho /
+                  opac.AbsorptionCoefficient(rho, T, Ye, type, nu, lambda) *
+                  opac.DThermalDistributionOfTNuDT(T, type, nu) * nu * dlnu;
+              kappaRosselandDenom +=
+                  opac.DThermalDistributionOfTNuDT(T, type, nu) * nu * dlnu;
+            }
+            Real lkappaPlanck = toLog_(kappaPlanckNum / kappaPlanckDenom);
+            Real lkappaRosseland =
+                toLog_(1. / (kappaRosselandNum / kappaRosselandDenom));
+            lkappaPlanck_(iRho, iT, iYe, idx) = lkappaPlanck;
+            lkappaRosseland_(iRho, iT, iYe, idx) = lkappaRosseland;
+          }
+        }
+      }
+    }
+  }
+
+  MeanOpacity GetOnDevice() {
+    MeanOpacity other;
+    other.lkappaPlanck_ = Spiner::getOnDeviceDataBox(lkappaPlanck_);
+    other.lkappaRosseland_ = Spiner::getOnDeviceDataBox(lkappaRosseland_);
+    return other;
+  }
+
+  void Finalize() {
+    lkappaPlanck_.finalize();
+    lkappaRosseland_.finalize();
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real PlanckMeanAbsorptionCoefficient(const Real rho, const Real temp,
+                                       const Real Ye,
+                                       const RadiationType type) const {
+    Real lRho = toLog_(rho);
+    Real lT = toLog_(temp);
+    int idx = RadType2Idx(type);
+    return rho * fromLog_(lkappaPlanck_.interpToReal(lRho, lT, Ye, idx));
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real RosselandMeanAbsorptionCoefficient(const Real rho, const Real temp,
+                                          const Real Ye,
+                                          const RadiationType type) const {
+    Real lRho = toLog_(rho);
+    Real lT = toLog_(temp);
+    int idx = RadType2Idx(type);
+    return rho * fromLog_(lkappaRosseland_.interpToReal(lRho, lT, Ye, idx));
+  }
+
+ private:
+  PORTABLE_INLINE_FUNCTION Real toLog_(const Real x) const {
+    return std::log10(std::abs(x) + EPS);
+  }
+  PORTABLE_INLINE_FUNCTION Real fromLog_(const Real lx) const {
+    return std::pow(10., lx);
+  }
+  Spiner::DataBox lkappaPlanck_;
+  Spiner::DataBox lkappaRosseland_;
+};
+
+} // namespace neutrinos
+} // namespace singularity
+
+#endif // SINGULARITY_OPAC_NEUTRINOS_MEAN_OPACITY_NEUTRINOS__

--- a/singularity-opac/neutrinos/mean_opacity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/mean_opacity_neutrinos.hpp
@@ -20,6 +20,7 @@
 
 #include <ports-of-call/portability.hpp>
 #include <singularity-opac/base/radiation_types.hpp>
+#include <singularity-opac/base/sp5.hpp>
 #include <singularity-opac/constants/constants.hpp>
 #include <spiner/databox.hpp>
 
@@ -128,12 +129,12 @@ class MeanOpacity {
   }
 
 #ifdef SPINER_USE_HDF
-  MeanOpacity(const std::string &filename)
-      : filename_(filename.c_str()), memoryStatus_(impl::DataStatus::OnHost) {
+  MeanOpacity(const std::string &filename) : filename_(filename.c_str()) {
     herr_t status = H5_SUCCESS;
     hid_t file = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
-    status += lkappaPlanck_.loadHDF(file, SP5::Opac::PlanckMeanOpacity);
-    status += lkappaRosseland_.loadHDF(file, SP5::Opac::RosselandMeanOpacity);
+    status += lkappaPlanck_.loadHDF(file, SP5::MeanOpac::PlanckMeanOpacity);
+    status +=
+        lkappaRosseland_.loadHDF(file, SP5::MeanOpac::RosselandMeanOpacity);
     status += H5Fclose(file);
 
     if (status != H5_SUCCESS) {
@@ -145,8 +146,9 @@ class MeanOpacity {
     herr_t status = H5_SUCCESS;
     hid_t file =
         H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
-    status += lkappaPlanck_.saveHDF(file, SP5::Opac::PlanckMeanOpacity);
-    status += lkappaRosseland_.saveHDF(file, SP5::Opac::RosselandMeanOpacity);
+    status += lkappaPlanck_.saveHDF(file, SP5::MeanOpac::PlanckMeanOpacity);
+    status +=
+        lkappaRosseland_.saveHDF(file, SP5::MeanOpac::RosselandMeanOpacity);
     status += H5Fclose(file);
 
     if (status != H5_SUCCESS) {
@@ -204,6 +206,7 @@ class MeanOpacity {
   Spiner::DataBox lkappaPlanck_;
   Spiner::DataBox lkappaRosseland_;
   int nlambda_;
+  const char *filename_;
 };
 
 } // namespace neutrinos

--- a/singularity-opac/neutrinos/mean_opacity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/mean_opacity_neutrinos.hpp
@@ -128,7 +128,7 @@ class MeanOpacity {
   }
 
 #ifdef SPINER_USE_HDF
-  SpinerOpacity(const std::string &filename)
+  MeanOpacity(const std::string &filename)
       : filename_(filename.c_str()), memoryStatus_(impl::DataStatus::OnHost) {
     herr_t status = H5_SUCCESS;
     hid_t file = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);

--- a/singularity-opac/neutrinos/mean_opacity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/mean_opacity_neutrinos.hpp
@@ -41,8 +41,6 @@ class MeanOpacity {
   MeanOpacity(const Opacity &opac, Real lRhoMin, Real lRhoMax, int NRho,
               Real lTMin, Real lTMax, int NT, Real YeMin, Real YeMax, int NYe,
               Real *lambda = nullptr) {
-    nlambda_ = opac.nlambda();
-
     lkappaPlanck_.resize(NRho, NT, NYe, NEUTRINO_NTYPES);
     // index 0 is the species and is not interpolatable
     lkappaPlanck_.setRange(1, YeMin, YeMax, NYe);
@@ -157,15 +155,12 @@ class MeanOpacity {
   }
 #endif
 
-  PORTABLE_INLINE_FUNCTION int nlambda() const { return nlambda_; }
-
   PORTABLE_INLINE_FUNCTION void PrintParams() const {
     printf("Mean opacity\n");
   }
 
   MeanOpacity GetOnDevice() {
     MeanOpacity other;
-    other.nlambda_ = nlambda_;
     other.lkappaPlanck_ = Spiner::getOnDeviceDataBox(lkappaPlanck_);
     other.lkappaRosseland_ = Spiner::getOnDeviceDataBox(lkappaRosseland_);
     return other;
@@ -205,9 +200,10 @@ class MeanOpacity {
   }
   Spiner::DataBox lkappaPlanck_;
   Spiner::DataBox lkappaRosseland_;
-  int nlambda_;
   const char *filename_;
 };
+
+#undef EPS
 
 } // namespace neutrinos
 } // namespace singularity

--- a/singularity-opac/neutrinos/neutrino_variant.hpp
+++ b/singularity-opac/neutrinos/neutrino_variant.hpp
@@ -126,6 +126,34 @@ class Variant {
         opac_);
   }
 
+  // Planck mean absorption coefficient with units of 1/length
+  // Signature should be at least
+  // rho, temp, Ye, type, lambda
+  PORTABLE_INLINE_FUNCTION Real PlanckMeanAbsorptionCoefficient(
+      const Real rho, const Real temp, const Real Ye, const RadiationType type,
+      Real *lambda = nullptr) const {
+    return mpark::visit(
+        [=](const auto &opac) {
+          return opac.PlanckMeanAbsorptionCoefficient(rho, temp, Ye, type,
+                                                      lambda);
+        },
+        opac_);
+  }
+
+  // Rosseland mean absorption coefficient with units of 1/length
+  // Signature should be at least
+  // rho, temp, Ye, type, lambda
+  PORTABLE_INLINE_FUNCTION Real RosselandMeanAbsorptionCoefficient(
+      const Real rho, const Real temp, const Real Ye, const RadiationType type,
+      Real *lambda = nullptr) const {
+    return mpark::visit(
+        [=](const auto &opac) {
+          return opac.RosselandMeanAbsorptionCoefficient(rho, temp, Ye, type,
+                                                         lambda);
+        },
+        opac_);
+  }
+
   // emissivity with units of energy/time/frequency/volume/angle
   // signature should be at least rho, temp, Ye, type, nu, lambda
   PORTABLE_INLINE_FUNCTION Real EmissivityPerNuOmega(

--- a/singularity-opac/neutrinos/neutrino_variant.hpp
+++ b/singularity-opac/neutrinos/neutrino_variant.hpp
@@ -242,6 +242,17 @@ class Variant {
         opac_);
   }
 
+  // Temperature derivative of specific intensity of thermal distribution
+  PORTABLE_INLINE_FUNCTION Real
+  DThermalDistributionOfTNuDT(const Real temp, const RadiationType type,
+                              const Real nu, Real *lambda = nullptr) const {
+    return mpark::visit(
+        [=](const auto &opac) {
+          return opac.DThermalDistributionOfTNuDT(temp, type, nu, lambda);
+        },
+        opac_);
+  }
+
   // Energy density of thermal distribution
   PORTABLE_INLINE_FUNCTION Real ThermalDistributionOfT(
       const Real temp, const RadiationType type, Real *lambda = nullptr) const {

--- a/singularity-opac/neutrinos/neutrino_variant.hpp
+++ b/singularity-opac/neutrinos/neutrino_variant.hpp
@@ -126,34 +126,6 @@ class Variant {
         opac_);
   }
 
-  // Planck mean absorption coefficient with units of 1/length
-  // Signature should be at least
-  // rho, temp, Ye, type, lambda
-  PORTABLE_INLINE_FUNCTION Real PlanckMeanAbsorptionCoefficient(
-      const Real rho, const Real temp, const Real Ye, const RadiationType type,
-      Real *lambda = nullptr) const {
-    return mpark::visit(
-        [=](const auto &opac) {
-          return opac.PlanckMeanAbsorptionCoefficient(rho, temp, Ye, type,
-                                                      lambda);
-        },
-        opac_);
-  }
-
-  // Rosseland mean absorption coefficient with units of 1/length
-  // Signature should be at least
-  // rho, temp, Ye, type, lambda
-  PORTABLE_INLINE_FUNCTION Real RosselandMeanAbsorptionCoefficient(
-      const Real rho, const Real temp, const Real Ye, const RadiationType type,
-      Real *lambda = nullptr) const {
-    return mpark::visit(
-        [=](const auto &opac) {
-          return opac.RosselandMeanAbsorptionCoefficient(rho, temp, Ye, type,
-                                                         lambda);
-        },
-        opac_);
-  }
-
   // emissivity with units of energy/time/frequency/volume/angle
   // signature should be at least rho, temp, Ye, type, nu, lambda
   PORTABLE_INLINE_FUNCTION Real EmissivityPerNuOmega(

--- a/singularity-opac/neutrinos/non_cgs_neutrinos.hpp
+++ b/singularity-opac/neutrinos/non_cgs_neutrinos.hpp
@@ -92,25 +92,6 @@ class NonCGSUnits {
     return alpha * length_unit_;
   }
 
-  PORTABLE_INLINE_FUNCTION
-  Real PlanckMeanAbsorptionCoefficient(const Real rho, const Real temp,
-                                       const Real Ye, const RadiationType type,
-                                       Real *lambda = nullptr) const {
-    const Real alpha = opac_.PlanckMeanAbsorptionCoefficient(
-        rho_unit_ * rho, temp_unit_ * temp, Ye, type, lambda);
-    return alpha * length_unit_;
-  }
-
-  PORTABLE_INLINE_FUNCTION
-  Real RosselandMeanAbsorptionCoefficient(const Real rho, const Real temp,
-                                          const Real Ye,
-                                          const RadiationType type,
-                                          Real *lambda = nullptr) const {
-    const Real alpha = opac_.RosselandMeanAbsorptionCoefficient(
-        rho_unit_ * rho, temp_unit_ * temp, Ye, type, lambda);
-    return alpha * length_unit_;
-  }
-
   // TODO(JMM): Doing the frequency conversion here is SUPER gross.
   // Is there no better way? Should we just not allow modified units?
   template <typename FrequencyIndexer, typename DataIndexer>

--- a/singularity-opac/neutrinos/non_cgs_neutrinos.hpp
+++ b/singularity-opac/neutrinos/non_cgs_neutrinos.hpp
@@ -235,6 +235,58 @@ class NonCGSUnits {
   Real inv_intensity_unit_, inv_energy_dens_unit_;
 };
 
+template <typename MeanOpac>
+class MeanNonCGSUnits {
+ public:
+  MeanNonCGSUnits() = default;
+  MeanNonCGSUnits(MeanOpac &&mean_opac, const Real time_unit,
+                  const Real mass_unit, const Real length_unit,
+                  const Real temp_unit)
+      : mean_opac_(std::forward<MeanOpac>(mean_opac)), time_unit_(time_unit),
+        mass_unit_(mass_unit), length_unit_(length_unit), temp_unit_(temp_unit),
+        rho_unit_(mass_unit_ / (length_unit_ * length_unit_ * length_unit_)) {}
+
+  auto GetOnDevice() {
+    return MeanNonCGSUnits<MeanOpac>(mean_opac_.GetOnDevice(), time_unit_,
+                                     mass_unit_, length_unit_, temp_unit_);
+  }
+  inline void Finalize() noexcept { mean_opac_.Finalize(); }
+
+  PORTABLE_INLINE_FUNCTION
+  int nlambda() const noexcept { return mean_opac_.nlambda(); }
+
+  PORTABLE_INLINE_FUNCTION
+  Real PlanckMeanAbsorptionCoefficient(const Real rho, const Real temp,
+                                       const Real Ye,
+                                       const RadiationType type) const {
+    const Real alpha = mean_opac_.PlanckMeanAbsorptionCoefficient(
+        rho_unit_ * rho, temp_unit_ * temp, Ye, type);
+    // alpha output in units of 1/cm. Want to convert out of CGS.
+    // multiplication by length_unit converts length to cm.
+    // division converts length from cm to unit system.
+    // thus multiplication converts (1/cm) to unit system.
+    return alpha * length_unit_;
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real RosselandMeanAbsorptionCoefficient(const Real rho, const Real temp,
+                                          const Real Ye,
+                                          const RadiationType type) const {
+    const Real alpha = mean_opac_.RosselandMeanAbsorptionCoefficient(
+        rho_unit_ * rho, temp_unit_ * temp, Ye, type);
+    // alpha output in units of 1/cm. Want to convert out of CGS.
+    // multiplication by length_unit converts length to cm.
+    // division converts length from cm to unit system.
+    // thus multiplication converts (1/cm) to unit system.
+    return alpha * length_unit_;
+  }
+
+ private:
+  MeanOpac mean_opac_;
+  Real time_unit_, mass_unit_, length_unit_, temp_unit_;
+  Real rho_unit_;
+};
+
 } // namespace neutrinos
 } // namespace singularity
 

--- a/singularity-opac/neutrinos/non_cgs_neutrinos.hpp
+++ b/singularity-opac/neutrinos/non_cgs_neutrinos.hpp
@@ -207,6 +207,14 @@ class NonCGSUnits {
   }
 
   PORTABLE_INLINE_FUNCTION
+  Real DThermalDistributionOfTNuDT(const Real temp, const RadiationType type,
+                                   const Real nu,
+                                   Real *lambda = nullptr) const {
+    Real dBdToH = opac_.DThermalDistributionOfTNuDT(temp, type, nu, lambda);
+    return dBdToH * inv_intensity_unit_ * temp_unit_;
+  }
+
+  PORTABLE_INLINE_FUNCTION
   Real ThermalDistributionOfT(const Real temp, const RadiationType type,
                               Real *lambda = nullptr) const {
     Real BoH = opac_.ThermalDistributionOfT(temp, type, lambda);

--- a/singularity-opac/neutrinos/non_cgs_neutrinos.hpp
+++ b/singularity-opac/neutrinos/non_cgs_neutrinos.hpp
@@ -92,6 +92,25 @@ class NonCGSUnits {
     return alpha * length_unit_;
   }
 
+  PORTABLE_INLINE_FUNCTION
+  Real PlanckMeanAbsorptionCoefficient(const Real rho, const Real temp,
+                                       const Real Ye, const RadiationType type,
+                                       Real *lambda = nullptr) const {
+    const Real alpha = opac_.PlanckMeanAbsorptionCoefficient(
+        rho_unit_ * rho, temp_unit_ * temp, Ye, type, lambda);
+    return alpha * length_unit_;
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real RosselandMeanAbsorptionCoefficient(const Real rho, const Real temp,
+                                          const Real Ye,
+                                          const RadiationType type,
+                                          Real *lambda = nullptr) const {
+    const Real alpha = opac_.RosselandMeanAbsorptionCoefficient(
+        rho_unit_ * rho, temp_unit_ * temp, Ye, type, lambda);
+    return alpha * length_unit_;
+  }
+
   // TODO(JMM): Doing the frequency conversion here is SUPER gross.
   // Is there no better way? Should we just not allow modified units?
   template <typename FrequencyIndexer, typename DataIndexer>

--- a/singularity-opac/neutrinos/spiner_opac_neutrinos.hpp
+++ b/singularity-opac/neutrinos/spiner_opac_neutrinos.hpp
@@ -61,7 +61,7 @@ enum class DataStatus { Deallocated, OnDevice, OnHost };
 template <typename ThermalDistribution>
 class SpinerOpacity {
  public:
-  static constexpr Real EPS = 10.0 * std::numeric_limits<Real>::epsilon();
+  static constexpr Real EPS = 10.0 * std::numeric_limits<Real>::min();
   using pc = PhysicalConstants<CGS>;
   static constexpr Real Hz2MeV = pc::h / (1e6 * pc::eV);
   static constexpr Real MeV2Hz = 1 / Hz2MeV;
@@ -337,6 +337,13 @@ class SpinerOpacity {
   Real ThermalDistributionOfTNu(const Real temp, const RadiationType type,
                                 const Real nu, Real *lambda = nullptr) const {
     return dist_.ThermalDistributionOfTNu(temp, type, nu, lambda);
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real DThermalDistributionOfTNuDT(const Real temp, const RadiationType type,
+                                   const Real nu,
+                                   Real *lambda = nullptr) const {
+    return dist_.DThermalDistributionOfTNuDT(temp, type, nu, lambda);
   }
 
   PORTABLE_INLINE_FUNCTION

--- a/singularity-opac/neutrinos/spiner_opac_neutrinos.hpp
+++ b/singularity-opac/neutrinos/spiner_opac_neutrinos.hpp
@@ -215,21 +215,6 @@ class SpinerOpacity {
     }
   }
 
-  PORTABLE_INLINE_FUNCTION
-  Real PlanckMeanAbsorptionCoefficient(const Real rho, const Real temp,
-                                       const Real Ye, const RadiationType type,
-                                       Real *lambda = nullptr) const {
-    OPAC_ERROR("Planck mean currently not implemented for tabulated data!");
-  }
-
-  PORTABLE_INLINE_FUNCTION
-  Real RosselandMeanAbsorptionCoefficient(const Real rho, const Real temp,
-                                          const Real Ye,
-                                          const RadiationType type,
-                                          Real *lambda = nullptr) const {
-    OPAC_ERROR("Rosseland mean currently not implemented for tabulated data!");
-  }
-
   // Angle-averaged absorption coefficient assumed to be the same as absorption
   // coefficient
   PORTABLE_INLINE_FUNCTION

--- a/singularity-opac/neutrinos/spiner_opac_neutrinos.hpp
+++ b/singularity-opac/neutrinos/spiner_opac_neutrinos.hpp
@@ -215,6 +215,21 @@ class SpinerOpacity {
     }
   }
 
+  PORTABLE_INLINE_FUNCTION
+  Real PlanckMeanAbsorptionCoefficient(const Real rho, const Real temp,
+                                       const Real Ye, const RadiationType type,
+                                       Real *lambda = nullptr) const {
+    OPAC_ERROR("Planck mean currently not implemented for tabulated data!");
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real RosselandMeanAbsorptionCoefficient(const Real rho, const Real temp,
+                                          const Real Ye,
+                                          const RadiationType type,
+                                          Real *lambda = nullptr) const {
+    OPAC_ERROR("Rosseland mean currently not implemented for tabulated data!");
+  }
+
   // Angle-averaged absorption coefficient assumed to be the same as absorption
   // coefficient
   PORTABLE_INLINE_FUNCTION

--- a/singularity-opac/neutrinos/thermal_distributions_neutrinos.hpp
+++ b/singularity-opac/neutrinos/thermal_distributions_neutrinos.hpp
@@ -27,7 +27,7 @@ namespace neutrinos {
 
 using pc = PhysicalConstants<CGS>;
 
-#define EPS (10.0 * std::numeric_limits<Real>::epsilon())
+#define EPS (10.0 * std::numeric_limits<Real>::min())
 
 template <int NSPECIES>
 struct FermiDiracDistributionNoMu {
@@ -38,6 +38,17 @@ struct FermiDiracDistributionNoMu {
     Real Bnu = NSPECIES * (2. * pc::h * nu * nu * nu / (pc::c * pc::c)) * 1. /
                (std::exp(x) + 1.);
     return Bnu;
+  }
+  PORTABLE_INLINE_FUNCTION
+  Real DThermalDistributionOfTNuDT(const Real temp, const RadiationType type,
+                                   const Real nu,
+                                   Real *lambda = nullptr) const {
+    Real x = pc::h * nu / (pc::kb * temp);
+    Real dBnudT = NSPECIES *
+                  (2. * pc::h * pc::h * nu * nu * nu * nu /
+                   (temp * temp * pc::c * pc::c * pc::kb)) *
+                  1. / (std::exp(x) + 1.);
+    return dBnudT;
   }
   PORTABLE_INLINE_FUNCTION
   Real ThermalDistributionOfT(const Real temp, const RadiationType type,

--- a/singularity-opac/neutrinos/tophat_emissivity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/tophat_emissivity_neutrinos.hpp
@@ -72,6 +72,21 @@ class TophatEmissivity {
   }
 
   PORTABLE_INLINE_FUNCTION
+  Real PlanckMeanAbsorptionCoefficient(const Real rho, const Real temp,
+                                       const Real Ye, const RadiationType type,
+                                       Real *lambda = nullptr) const {
+    OPAC_ERROR("Planck mean currently not implemented for tophat!");
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real RosselandMeanAbsorptionCoefficient(const Real rho, const Real temp,
+                                          const Real Ye,
+                                          const RadiationType type,
+                                          Real *lambda = nullptr) const {
+    OPAC_ERROR("Rosseland mean currently not implemented for tophat!");
+  }
+
+  PORTABLE_INLINE_FUNCTION
   Real AngleAveragedAbsorptionCoefficient(const Real rho, const Real temp,
                                           const Real Ye,
                                           const RadiationType type,

--- a/singularity-opac/neutrinos/tophat_emissivity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/tophat_emissivity_neutrinos.hpp
@@ -72,21 +72,6 @@ class TophatEmissivity {
   }
 
   PORTABLE_INLINE_FUNCTION
-  Real PlanckMeanAbsorptionCoefficient(const Real rho, const Real temp,
-                                       const Real Ye, const RadiationType type,
-                                       Real *lambda = nullptr) const {
-    OPAC_ERROR("Planck mean currently not implemented for tophat!");
-  }
-
-  PORTABLE_INLINE_FUNCTION
-  Real RosselandMeanAbsorptionCoefficient(const Real rho, const Real temp,
-                                          const Real Ye,
-                                          const RadiationType type,
-                                          Real *lambda = nullptr) const {
-    OPAC_ERROR("Rosseland mean currently not implemented for tophat!");
-  }
-
-  PORTABLE_INLINE_FUNCTION
   Real AngleAveragedAbsorptionCoefficient(const Real rho, const Real temp,
                                           const Real Ye,
                                           const RadiationType type,

--- a/singularity-opac/neutrinos/tophat_emissivity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/tophat_emissivity_neutrinos.hpp
@@ -170,6 +170,13 @@ class TophatEmissivity {
   }
 
   PORTABLE_INLINE_FUNCTION
+  Real DThermalDistributionOfTNuDT(const Real temp, const RadiationType type,
+                                   const Real nu,
+                                   Real *lambda = nullptr) const {
+    return dist_.DThermalDistributionOfTNuDT(temp, type, nu, lambda);
+  }
+
+  PORTABLE_INLINE_FUNCTION
   Real ThermalDistributionOfT(const Real temp, const RadiationType type,
                               Real *lambda = nullptr) const {
     return dist_.ThermalDistributionOfT(temp, type, lambda);

--- a/singularity-opac/photons/gray_opacity_photons.hpp
+++ b/singularity-opac/photons/gray_opacity_photons.hpp
@@ -43,37 +43,52 @@ class GrayOpacity {
   inline void Finalize() noexcept {}
 
   PORTABLE_INLINE_FUNCTION
-  Real AbsorptionCoefficientPerNu(const Real rho, const Real temp,
-                                  const Real nu, Real *lambda = nullptr) const {
+  Real AbsorptionCoefficient(const Real rho, const Real temp, const Real nu,
+                             Real *lambda = nullptr) const {
     return dist_.AbsorptionCoefficientFromKirkhoff(*this, rho, temp, nu,
                                                    lambda);
   }
 
   template <typename FrequencyIndexer, typename DataIndexer>
   PORTABLE_INLINE_FUNCTION void
-  AbsorptionCoefficientPerNu(const Real rho, const Real temp,
-                             FrequencyIndexer &nu_bins, DataIndexer &coeffs,
-                             const int nbins, Real *lambda = nullptr) const {
+  AbsorptionCoefficient(const Real rho, const Real temp,
+                        FrequencyIndexer &nu_bins, DataIndexer &coeffs,
+                        const int nbins, Real *lambda = nullptr) const {
     for (int i = 0; i < nbins; ++i) {
-      coeffs[i] = AbsorptionCoefficientPerNu(rho, temp, nu_bins[i], lambda);
+      coeffs[i] = AbsorptionCoefficient(rho, temp, nu_bins[i], lambda);
     }
   }
 
   PORTABLE_INLINE_FUNCTION
-  Real AngleAveragedAbsorptionCoefficientPerNu(const Real rho, const Real temp,
-                                               const Real nu,
-                                               Real *lambda = nullptr) const {
+  Real PlanckMeanAbsorptionCoefficient(const Real rho, const Real temp,
+                                       const Real Ye, const RadiationType type,
+                                       Real *lambda = nullptr) const {
+    return rho * kappa_;
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real RosselandMeanAbsorptionCoefficient(const Real rho, const Real temp,
+                                          const Real Ye,
+                                          const RadiationType type,
+                                          Real *lambda = nullptr) const {
+    return rho * kappa_;
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real AngleAveragedAbsorptionCoefficient(const Real rho, const Real temp,
+                                          const Real nu,
+                                          Real *lambda = nullptr) const {
     return dist_.AngleAveragedAbsorptionCoefficientFromKirkhoff(
         *this, rho, temp, nu, lambda);
   }
 
   template <typename FrequencyIndexer, typename DataIndexer>
-  PORTABLE_INLINE_FUNCTION void AngleAveragedAbsorptionCoefficientPerNu(
+  PORTABLE_INLINE_FUNCTION void AngleAveragedAbsorptionCoefficient(
       const Real rho, const Real temp, FrequencyIndexer &nu_bins,
       DataIndexer &coeffs, const int nbins, Real *lambda = nullptr) const {
     for (int i = 0; i < nbins; ++i) {
-      coeffs[i] = AngleAveragedAbsorptionCoefficientPerNu(rho, temp, nu_bins[i],
-                                                          lambda);
+      coeffs[i] =
+          AngleAveragedAbsorptionCoefficient(rho, temp, nu_bins[i], lambda);
     }
   }
 

--- a/singularity-opac/photons/gray_opacity_photons.hpp
+++ b/singularity-opac/photons/gray_opacity_photons.hpp
@@ -145,6 +145,12 @@ class GrayOpacity {
   }
 
   PORTABLE_INLINE_FUNCTION
+  Real DThermalDistributionOfTNuDT(const Real temp, const Real nu,
+                                   Real *lambda = nullptr) const {
+    return dist_.DThermalDistributionOfTNuDT(temp, nu, lambda);
+  }
+
+  PORTABLE_INLINE_FUNCTION
   Real ThermalDistributionOfT(const Real temp, Real *lambda = nullptr) const {
     return dist_.ThermalDistributionOfT(temp, lambda);
   }

--- a/singularity-opac/photons/gray_opacity_photons.hpp
+++ b/singularity-opac/photons/gray_opacity_photons.hpp
@@ -60,21 +60,6 @@ class GrayOpacity {
   }
 
   PORTABLE_INLINE_FUNCTION
-  Real PlanckMeanAbsorptionCoefficient(const Real rho, const Real temp,
-                                       const Real Ye, const RadiationType type,
-                                       Real *lambda = nullptr) const {
-    return rho * kappa_;
-  }
-
-  PORTABLE_INLINE_FUNCTION
-  Real RosselandMeanAbsorptionCoefficient(const Real rho, const Real temp,
-                                          const Real Ye,
-                                          const RadiationType type,
-                                          Real *lambda = nullptr) const {
-    return rho * kappa_;
-  }
-
-  PORTABLE_INLINE_FUNCTION
   Real AngleAveragedAbsorptionCoefficient(const Real rho, const Real temp,
                                           const Real nu,
                                           Real *lambda = nullptr) const {

--- a/singularity-opac/photons/non_cgs_photons.hpp
+++ b/singularity-opac/photons/non_cgs_photons.hpp
@@ -190,6 +190,13 @@ class NonCGSUnits {
   }
 
   PORTABLE_INLINE_FUNCTION
+  Real DThermalDistributionOfTNuDT(const Real temp, const Real nu,
+                                   Real *lambda = nullptr) const {
+    Real dBdToH = opac_.DThermalDistributionOfTNuDT(temp, nu, lambda);
+    return dBdToH * inv_intensity_unit_ * temp_unit_;
+  }
+
+  PORTABLE_INLINE_FUNCTION
   Real ThermalDistributionOfT(const Real temp, Real *lambda = nullptr) const {
     Real BoH = opac_.ThermalDistributionOfT(temp, lambda);
     return BoH * inv_energy_dens_unit_;

--- a/singularity-opac/photons/non_cgs_photons.hpp
+++ b/singularity-opac/photons/non_cgs_photons.hpp
@@ -77,6 +77,22 @@ class NonCGSUnits {
   }
 
   PORTABLE_INLINE_FUNCTION
+  Real PlanckMeanAbsorptionCoefficient(const Real rho, const Real temp,
+                                       Real *lambda = nullptr) const {
+    const Real alpha = opac_.PlanckMeanAbsorptionCoefficient(
+        rho_unit_ * rho, temp_unit_ * temp, lambda);
+    return alpha * length_unit_;
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real RosselandMeanAbsorptionCoefficient(const Real rho, const Real temp,
+                                          Real *lambda = nullptr) const {
+    const Real alpha = opac_.RosselandMeanAbsorptionCoefficient(
+        rho_unit_ * rho, temp_unit_ * temp, lambda);
+    return alpha * length_unit_;
+  }
+
+  PORTABLE_INLINE_FUNCTION
   Real AngleAveragedAbsorptionCoefficient(const Real rho, const Real temp,
                                           const Real nu,
                                           Real *lambda = nullptr) const {

--- a/singularity-opac/photons/non_cgs_photons.hpp
+++ b/singularity-opac/photons/non_cgs_photons.hpp
@@ -77,22 +77,6 @@ class NonCGSUnits {
   }
 
   PORTABLE_INLINE_FUNCTION
-  Real PlanckMeanAbsorptionCoefficient(const Real rho, const Real temp,
-                                       Real *lambda = nullptr) const {
-    const Real alpha = opac_.PlanckMeanAbsorptionCoefficient(
-        rho_unit_ * rho, temp_unit_ * temp, lambda);
-    return alpha * length_unit_;
-  }
-
-  PORTABLE_INLINE_FUNCTION
-  Real RosselandMeanAbsorptionCoefficient(const Real rho, const Real temp,
-                                          Real *lambda = nullptr) const {
-    const Real alpha = opac_.RosselandMeanAbsorptionCoefficient(
-        rho_unit_ * rho, temp_unit_ * temp, lambda);
-    return alpha * length_unit_;
-  }
-
-  PORTABLE_INLINE_FUNCTION
   Real AngleAveragedAbsorptionCoefficient(const Real rho, const Real temp,
                                           const Real nu,
                                           Real *lambda = nullptr) const {

--- a/singularity-opac/photons/photon_variant.hpp
+++ b/singularity-opac/photons/photon_variant.hpp
@@ -97,30 +97,6 @@ class Variant {
         opac_);
   }
 
-  // Planck mean absorption coefficient with units of 1/length
-  // Signature should be at least
-  // rho, temp, lambda
-  PORTABLE_INLINE_FUNCTION Real PlanckMeanAbsorptionCoefficient(
-      const Real rho, const Real temp, Real *lambda = nullptr) const {
-    return mpark::visit(
-        [=](const auto &opac) {
-          return opac.PlanckMeanAbsorptionCoefficient(rho, temp, lambda);
-        },
-        opac_);
-  }
-
-  // Rosseland mean absorption coefficient with units of 1/length
-  // Signature should be at least
-  // rho, temp, lambda
-  PORTABLE_INLINE_FUNCTION Real RosselandMeanAbsorptionCoefficient(
-      const Real rho, const Real temp, Real *lambda = nullptr) const {
-    return mpark::visit(
-        [=](const auto &opac) {
-          return opac.RosselandMeanAbsorptionCoefficient(rho, temp, lambda);
-        },
-        opac_);
-  }
-
   // Angle-averaged absorption coefficient with units of 1/length
   // Signature should be at least
   // rho, temp, nu, lambda

--- a/singularity-opac/photons/photon_variant.hpp
+++ b/singularity-opac/photons/photon_variant.hpp
@@ -224,6 +224,16 @@ class Variant {
         opac_);
   }
 
+  // Temperature derivative of specific intensity of thermal distribution
+  PORTABLE_INLINE_FUNCTION Real DThermalDistributionOfTNuDT(
+      const Real temp, const Real nu, Real *lambda = nullptr) const {
+    return mpark::visit(
+        [=](const auto &opac) {
+          return opac.DThermalDistributionOfTNuDT(temp, nu, lambda);
+        },
+        opac_);
+  }
+
   // Energy density of thermal distribution
   PORTABLE_INLINE_FUNCTION Real
   ThermalDistributionOfT(const Real temp, Real *lambda = nullptr) const {

--- a/singularity-opac/photons/photon_variant.hpp
+++ b/singularity-opac/photons/photon_variant.hpp
@@ -97,6 +97,30 @@ class Variant {
         opac_);
   }
 
+  // Planck mean absorption coefficient with units of 1/length
+  // Signature should be at least
+  // rho, temp, lambda
+  PORTABLE_INLINE_FUNCTION Real PlanckMeanAbsorptionCoefficient(
+      const Real rho, const Real temp, Real *lambda = nullptr) const {
+    return mpark::visit(
+        [=](const auto &opac) {
+          return opac.PlanckMeanAbsorptionCoefficient(rho, temp, lambda);
+        },
+        opac_);
+  }
+
+  // Rosseland mean absorption coefficient with units of 1/length
+  // Signature should be at least
+  // rho, temp, lambda
+  PORTABLE_INLINE_FUNCTION Real RosselandMeanAbsorptionCoefficient(
+      const Real rho, const Real temp, Real *lambda = nullptr) const {
+    return mpark::visit(
+        [=](const auto &opac) {
+          return opac.RosselandMeanAbsorptionCoefficient(rho, temp, lambda);
+        },
+        opac_);
+  }
+
   // Angle-averaged absorption coefficient with units of 1/length
   // Signature should be at least
   // rho, temp, nu, lambda

--- a/singularity-opac/photons/thermal_distributions_photons.hpp
+++ b/singularity-opac/photons/thermal_distributions_photons.hpp
@@ -37,6 +37,15 @@ struct PlanckDistribution {
     return Bnu;
   }
   PORTABLE_INLINE_FUNCTION
+  Real DThermalDistributionOfTNuDT(const Real temp, const Real nu,
+                                   Real *lambda = nullptr) const {
+    Real x = pc::h * nu / (pc::kb * temp);
+    Real dBnudT = (2. * pc::h * pc::h * nu * nu * nu * nu /
+                   (temp * temp * pc::c * pc::c * pc::kb)) *
+                  1. / (std::exp(x) + -1.);
+    return dBnudT;
+  }
+  PORTABLE_INLINE_FUNCTION
   Real ThermalDistributionOfT(const Real temp, Real *lambda = nullptr) const {
     return 8. * std::pow(M_PI, 5) * std::pow(pc::kb, 4) * std::pow(temp, 4) /
            (15. * std::pow(pc::c, 2) * std::pow(pc::h, 3));

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,6 +39,7 @@ PRIVATE
   test_brt_opacities.cpp
   test_chebyshev.cpp
   test_spiner_opac_neutrinos.cpp
+  test_mean_opacities.cpp
 )
 
 target_link_libraries(${PROJECT_NAME}_unit_tests

--- a/test/test_mean_opacities.cpp
+++ b/test/test_mean_opacities.cpp
@@ -1,0 +1,207 @@
+// ======================================================================
+// © 2022. Triad National Security, LLC. All rights reserved.  This
+// program was produced under U.S. Government contract
+// 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
+// is operated by Triad National Security, LLC for the U.S.
+// Department of Energy/National Nuclear Security Administration. All
+// rights in the program are reserved by Triad National Security, LLC,
+// and the U.S. Department of Energy/National Nuclear Security
+// Administration. The Government is granted for itself and others
+// acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works,
+// distribute copies to the public, perform publicly and display
+// publicly, and to permit others to do so.
+// ======================================================================
+
+#include <cmath>
+#include <iostream>
+
+#include <catch2/catch.hpp>
+
+#include <ports-of-call/portability.hpp>
+#include <ports-of-call/portable_arrays.hpp>
+#include <spiner/databox.hpp>
+
+#include <singularity-opac/base/indexers.hpp>
+#include <singularity-opac/base/radiation_types.hpp>
+#include <singularity-opac/chebyshev/chebyshev.hpp>
+#include <singularity-opac/constants/constants.hpp>
+#include <singularity-opac/neutrinos/mean_opacity_neutrinos.hpp>
+#include <singularity-opac/neutrinos/opac_neutrinos.hpp>
+#include <singularity-opac/photons/opac_photons.hpp>
+
+using namespace singularity;
+
+using pc = PhysicalConstants<CGS>;
+
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+using atomic_view = Kokkos::MemoryTraits<Kokkos::Atomic>;
+#endif
+
+template <typename T>
+PORTABLE_INLINE_FUNCTION T FractionalDifference(const T &a, const T &b) {
+  return 2 * std::abs(b - a) / (std::abs(a) + std::abs(b) + 1e-20);
+}
+constexpr Real EPS_TEST = 1e-3;
+
+TEST_CASE("Mean neutrino opacities", "[MeanNeutrinos]") {
+  WHEN("We initialize a mean neutrino opacity") {
+    constexpr Real MeV2K = 1e6 * pc::eV / pc::kb;
+    constexpr Real MeV2Hz = 1e6 * pc::eV / pc::h;
+    constexpr Real rho = 1e11;        // g/cc
+    constexpr Real temp = 10 * MeV2K; // 10 MeV
+    constexpr Real Ye = 0.1;
+    constexpr RadiationType type = RadiationType::NU_ELECTRON;
+    constexpr Real nu = 1.25 * MeV2Hz; // 1 MeV
+
+    constexpr int nT = 10;
+    constexpr Real lRhoMin = std::log10(0.1 * rho);
+    constexpr Real lRhoMax = std::log10(10. * rho);
+    constexpr int NRho = 2;
+    constexpr Real lTMin = std::log10(0.1 * temp);
+    constexpr Real lTMax = std::log10(10. * temp);
+    constexpr int NT = 10;
+    constexpr Real YeMin = 0.1;
+    constexpr Real YeMax = 0.5;
+    constexpr int NYe = 10;
+
+    constexpr Real kappa = 1.e-20;
+
+    neutrinos::Gray opac_host(kappa);
+    neutrinos::Opacity opac = opac_host.GetOnDevice();
+
+    neutrinos::MeanOpacity mean_opac_host(opac_host, lRhoMin, lRhoMax, NRho,
+                                          lTMin, lTMax, NT, YeMin, YeMax, NYe);
+    neutrinos::MeanOpacity mean_opac = mean_opac_host.GetOnDevice();
+
+    THEN("The emissivity per nu omega is consistent with the emissity per nu") {
+      int n_wrong_h = 0;
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+      Kokkos::View<int, atomic_view> n_wrong_d("wrong");
+#else
+      PortableMDArray<int> n_wrong_d(&n_wrong_h, 1);
+#endif
+
+      portableFor(
+          "calc mean opacities", 0, 100, PORTABLE_LAMBDA(const int &i) {
+            Real alphaPlanck =
+                mean_opac.PlanckMeanAbsorptionCoefficient(rho, temp, Ye, type);
+            Real alphaRosseland =
+                mean_opac.PlanckMeanAbsorptionCoefficient(rho, temp, Ye, type);
+            if (FractionalDifference(kappa * rho, alphaPlanck) > EPS_TEST) {
+              n_wrong_d() += 1;
+            }
+            if (FractionalDifference(kappa * rho, alphaRosseland) > EPS_TEST) {
+              n_wrong_d() += 1;
+            }
+          });
+
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+      Kokkos::deep_copy(n_wrong_h, n_wrong_d);
+#endif
+      REQUIRE(n_wrong_h == 0);
+    }
+
+#ifdef SPINER_USE_HDF
+    THEN("We can save to disk and reload") {
+      mean_opac.Save(grayname);
+      neutrinos::MeanOpacity mean_opac_host_load =
+          neutrinos::MeanOpacity(grayname);
+      AND_THEN("The reloaded table matches the gray opacities") {
+
+        neutrinos::MeanOpacity mean_opac_load =
+            mean_opac_load_host.GetOnDevice();
+
+        int n_wrong = 0;
+        portableReduce(
+            "rebuilt table vs gray", 0, NRho, 0, NT, 0, NYe, 0, NEUTRINO_NTYPES,
+            0, Ne,
+            PORTABLE_LAMBDA(const int iRho, const int iT, const int iYe,
+                            const int itp, const int ie, int &accumulate) {
+              const Real lRho =
+                  lRhoMin + (lRhoMax - lRhoMin) / (NRho - 1) * iRho;
+              const Real rho = std::pow(10, lRho);
+              const Real lT = lTMin + (lTMax - lTMin) / (NT - 1) * iT;
+              const Real T = std::pow(10, lT);
+              const Real Ye = YeMin + (YeMax - YeMin) / (NYe - 1) * iYe;
+              const RadiationType type = Idx2RadType(itp);
+
+              const Real kappaPgray =
+                  mean_opac.PlanckMeanAbsorptionCoefficient(rho, T, Ye, type);
+              const Real kappaPload =
+                  mean_opac_load.PlanckMeanAbsorptionCoefficient(rho, T, Ye,
+                                                                 type);
+
+              const Real kappaRgray =
+                  mean_opac.RosselandMeanAbsorptionCoefficient(rho, T, Ye,
+                                                               type);
+              const Real kappaRload =
+                  mean_opac_load.RosselandMeanAbsorptionCoefficient(rho, T, Ye,
+                                                                    type);
+
+              if (IsWrong(kappaPgray, kappaPload)) {
+                accumulate += 1;
+              }
+              if (IsWrong(kappaRgray, kappaRload)) {
+                accumulate += 1;
+              }
+            },
+            n_wrong);
+        REQUIRE(n_wrong == 0);
+      }
+    }
+#endif
+
+    THEN("We can create an opacity object with funny units") {
+      constexpr Real time_unit = 123;
+      constexpr Real mass_unit = 456;
+      constexpr Real length_unit = 789;
+      constexpr Real temp_unit = 276;
+      constexpr Real rho_unit =
+          mass_unit / (length_unit * length_unit * length_unit);
+
+      auto funny_units_host =
+          neutrinos::MeanNonCGSUnits<neutrinos::MeanOpacity>(
+              std::forward<neutrinos::MeanOpacity>(mean_opac_host), time_unit,
+              mass_unit, length_unit, temp_unit);
+
+      auto funny_units = funny_units_host.GetOnDevice();
+
+      int n_wrong_h = 0;
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+      Kokkos::View<int, atomic_view> n_wrong_d("wrong");
+#else
+      PortableMDArray<int> n_wrong_d(&n_wrong_h, 1);
+#endif
+
+      portableFor(
+          "compare different units", 0, 100, PORTABLE_LAMBDA(const int &i) {
+            Real alphaPlanck =
+                mean_opac.PlanckMeanAbsorptionCoefficient(rho, temp, Ye, type);
+            Real alphaRosseland = mean_opac.RosselandMeanAbsorptionCoefficient(
+                rho, temp, Ye, type);
+            Real alphaPlanckFunny = funny_units.PlanckMeanAbsorptionCoefficient(
+                rho / rho_unit, temp / temp_unit, Ye, type);
+            Real alphaRosselandFunny =
+                funny_units.RosselandMeanAbsorptionCoefficient(
+                    rho / rho_unit, temp / temp_unit, Ye, type);
+            if (FractionalDifference(alphaPlanck, alphaPlanckFunny /
+                                                      length_unit) > EPS_TEST) {
+              n_wrong_d() += 1;
+            }
+            if (FractionalDifference(alphaRosseland,
+                                     alphaRosselandFunny / length_unit) >
+                EPS_TEST) {
+              n_wrong_d() += 1;
+            }
+          });
+
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+      Kokkos::deep_copy(n_wrong_h, n_wrong_d);
+#endif
+      REQUIRE(n_wrong_h == 0);
+    }
+
+    opac.Finalize();
+  }
+}


### PR DESCRIPTION
Frequency-integrated methods require opacities in some frequency-averaged sense. This PR provides Planck and Rosseland mean opacities through the interface. Not all existing opacity models are supported right now, I want to at least get `BRT` though.