### PR TITLE
Add radiation temperature calls

### DIFF
--- a/singularity-opac/neutrinos/brt_neutrinos.hpp
+++ b/singularity-opac/neutrinos/brt_neutrinos.hpp
@@ -145,6 +145,24 @@ class BRTOpacity {
     return dist_.ThermalNumberDistributionOfT(temp, type, lambda);
   }
 
+  PORTABLE_INLINE_FUNCTION
+  Real EnergyDensityFromTemperature(const Real temp, const RadiationType type,
+                                    Real *lambda = nullptr) const {
+    return dist_.EnergyDensityFromTemperature(temp, type, lambda);
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real TemperatureFromEnergyDensity(const Real er, const RadiationType type,
+                                    Real *lambda = nullptr) const {
+    return dist_.TemperatureFromEnergyDensity(er, type, lambda);
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real NumberDensityFromTemperature(const Real temp, const RadiationType type,
+                                    Real *lambda = nullptr) const {
+    return dist_.NumberDensityFromTemperature(temp, type, lambda);
+  }
+
  private:
   Real GetSigmac(const RadiationType type, const Real nu) const {
     if (type != RadiationType::NU_ELECTRON) {

--- a/singularity-opac/neutrinos/gray_opacity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/gray_opacity_neutrinos.hpp
@@ -148,6 +148,24 @@ class GrayOpacity {
     return dist_.ThermalNumberDistributionOfT(temp, type, lambda);
   }
 
+  PORTABLE_INLINE_FUNCTION
+  Real EnergyDensityFromTemperature(const Real temp, const RadiationType type,
+                                    Real *lambda = nullptr) const {
+    return dist_.EnergyDensityFromTemperature(temp, type, lambda);
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real TemperatureFromEnergyDensity(const Real er, const RadiationType type,
+                                    Real *lambda = nullptr) const {
+    return dist_.TemperatureFromEnergyDensity(er, type, lambda);
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real NumberDensityFromTemperature(const Real temp, const RadiationType type,
+                                    Real *lambda = nullptr) const {
+    return dist_.NumberDensityFromTemperature(temp, type, lambda);
+  }
+
  private:
   Real kappa_; // Opacity. Units of cm^2/g
   ThermalDistribution dist_;

--- a/singularity-opac/neutrinos/neutrino_variant.hpp
+++ b/singularity-opac/neutrinos/neutrino_variant.hpp
@@ -214,7 +214,7 @@ class Variant {
         opac_);
   }
 
-  // Energy density of thermal distribution
+  // Integral of thermal distribution over frequency and angle
   PORTABLE_INLINE_FUNCTION Real ThermalDistributionOfT(
       const Real temp, const RadiationType type, Real *lambda = nullptr) const {
     return mpark::visit(
@@ -224,12 +224,42 @@ class Variant {
         opac_);
   }
 
-  // Number density of thermal distribution
+  // Integral of thermal distribution/energy over frequency and angle
   PORTABLE_INLINE_FUNCTION Real ThermalNumberDistributionOfT(
       const Real temp, const RadiationType type, Real *lambda = nullptr) const {
     return mpark::visit(
         [=](const auto &opac) {
           return opac.ThermalNumberDistributionOfT(temp, type, lambda);
+        },
+        opac_);
+  }
+
+  // Energy density of thermal distribution
+  PORTABLE_INLINE_FUNCTION Real EnergyDensityFromTemperature(
+      const Real temp, const RadiationType type, Real *lambda = nullptr) const {
+    return mpark::visit(
+        [=](const auto &opac) {
+          return opac.EnergyDensityFromTemperature(temp, type, lambda);
+        },
+        opac_);
+  }
+
+  // Temperature of thermal distribution
+  PORTABLE_INLINE_FUNCTION Real TemperatureFromEnergyDensity(
+      const Real er, const RadiationType type, Real *lambda = nullptr) const {
+    return mpark::visit(
+        [=](const auto &opac) {
+          return opac.TemperatureFromEnergyDensity(er, type, lambda);
+        },
+        opac_);
+  }
+
+  // Number density of thermal distribution
+  PORTABLE_INLINE_FUNCTION Real NumberDensityFromTemperature(
+      const Real temp, const RadiationType type, Real *lambda = nullptr) const {
+    return mpark::visit(
+        [=](const auto &opac) {
+          return opac.NumberDensityFromTemperature(temp, type, lambda);
         },
         opac_);
   }

--- a/singularity-opac/neutrinos/non_cgs_neutrinos.hpp
+++ b/singularity-opac/neutrinos/non_cgs_neutrinos.hpp
@@ -203,6 +203,30 @@ class NonCGSUnits {
     return NoH * mass_unit_ / rho_unit_ * time_unit_ / length_unit_;
   }
 
+  PORTABLE_INLINE_FUNCTION
+  Real EnergyDensityFromTemperature(const Real temp, const RadiationType type,
+                                    Real *lambda = nullptr) const {
+    Real BoH =
+        opac_.EnergyDensityFromTemperature(temp * temp_unit_, type, lambda);
+    return BoH * inv_energy_dens_unit_;
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real TemperatureFromEnergyDensity(const Real er, const RadiationType type,
+                                    Real *lambda = nullptr) const {
+    Real BoH = opac_.TemperatureFromEnergyDensity(er / inv_energy_dens_unit_,
+                                                  type, lambda);
+    return BoH / temp_unit_;
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real NumberDensityFromTemperature(const Real temp, const RadiationType type,
+                                    Real *lambda = nullptr) const {
+    Real NoH =
+        opac_.NumberDensityFromTemperature(temp * temp_unit_, type, lambda);
+    return NoH * mass_unit_ / rho_unit_;
+  }
+
  private:
   Opac opac_;
   Real time_unit_, mass_unit_, length_unit_, temp_unit_;

--- a/singularity-opac/neutrinos/spiner_opac_neutrinos.hpp
+++ b/singularity-opac/neutrinos/spiner_opac_neutrinos.hpp
@@ -335,6 +335,24 @@ class SpinerOpacity {
     return dist_.ThermalNumberDistributionOfT(temp, type, lambda);
   }
 
+  PORTABLE_INLINE_FUNCTION
+  Real EnergyDensityFromTemperature(const Real temp, const RadiationType type,
+                                    Real *lambda = nullptr) const {
+    return dist_.EnergyDensityFromTemperature(temp, type, lambda);
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real TemperatureFromEnergyDensity(const Real er, const RadiationType type,
+                                    Real *lambda = nullptr) const {
+    return dist_.TemperatureFromEnergyDensity(er, type, lambda);
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real NumberDensityFromTemperature(const Real temp, const RadiationType type,
+                                    Real *lambda = nullptr) const {
+    return dist_.NumberDensityFromTemperature(temp, type, lambda);
+  }
+
  private:
   // TODO(JMM): Offsets probably not necessary
   PORTABLE_INLINE_FUNCTION Real toLog_(const Real x, const Real offset) const {

--- a/singularity-opac/neutrinos/thermal_distributions_neutrinos.hpp
+++ b/singularity-opac/neutrinos/thermal_distributions_neutrinos.hpp
@@ -52,6 +52,24 @@ struct FermiDiracDistributionNoMu {
     return 12. * pow(pc::kb, 3) * M_PI * NSPECIES * pow(temp, 3) * zeta3 /
            (pow(pc::c, 2) * pow(pc::h, 3));
   }
+  PORTABLE_INLINE_FUNCTION
+  Real EnergyDensityFromTemperature(const Real temp, const RadiationType type,
+                                    Real *lambda = nullptr) const {
+    return ThermalDistributionOfT(temp, type, lambda) / pc::c;
+  }
+  PORTABLE_INLINE_FUNCTION
+  Real TemperatureFromEnergyDensity(const Real er, const RadiationType type,
+                                    Real *lambda = nullptr) const {
+    return std::pow(
+        15. * std::pow(pc::c, 3) * std::pow(pc::h, 3) * er /
+            (7. * std::pow(M_PI, 5) * std::pow(pc::kb, 4) * NSPECIES),
+        1. / 4.);
+  }
+  PORTABLE_INLINE_FUNCTION
+  Real NumberDensityFromTemperature(const Real temp, const RadiationType type,
+                                    Real *lambda = nullptr) const {
+    return ThermalNumberDistributionOfT(temp, type, lambda) / pc::c;
+  }
   template <typename Emissivity>
   PORTABLE_INLINE_FUNCTION Real AbsorptionCoefficientFromKirkhoff(
       const Emissivity &J, const Real rho, const Real temp, const Real Ye,

--- a/singularity-opac/neutrinos/tophat_emissivity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/tophat_emissivity_neutrinos.hpp
@@ -165,6 +165,24 @@ class TophatEmissivity {
     return dist_.ThermalNumberDistributionOfT(temp, type, lambda);
   }
 
+  PORTABLE_INLINE_FUNCTION
+  Real EnergyDensityFromTemperature(const Real temp, const RadiationType type,
+                                    Real *lambda = nullptr) const {
+    return dist_.EnergyDensityFromTemperature(temp, type, lambda);
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real TemperatureFromEnergyDensity(const Real er, const RadiationType type,
+                                    Real *lambda = nullptr) const {
+    return dist_.TemperatureFromEnergyDensity(er, type, lambda);
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real NumberDensityFromTemperature(const Real temp, const RadiationType type,
+                                    Real *lambda = nullptr) const {
+    return dist_.NumberDensityFromTemperature(temp, type, lambda);
+  }
+
  private:
   PORTABLE_INLINE_FUNCTION
   Real GetYeF(RadiationType type, Real Ye) const {

--- a/singularity-opac/photons/gray_opacity_photons.hpp
+++ b/singularity-opac/photons/gray_opacity_photons.hpp
@@ -139,6 +139,24 @@ class GrayOpacity {
     return dist_.ThermalNumberDistributionOfT(temp, lambda);
   }
 
+  PORTABLE_INLINE_FUNCTION
+  Real EnergyDensityFromTemperature(const Real temp,
+                                    Real *lambda = nullptr) const {
+    return dist_.EnergyDensityFromTemperature(temp, lambda);
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real TemperatureFromEnergyDensity(const Real er,
+                                    Real *lambda = nullptr) const {
+    return dist_.TemperatureFromEnergyDensity(er, lambda);
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real NumberDensityFromTemperature(const Real temp,
+                                    Real *lambda = nullptr) const {
+    return dist_.NumberDensityFromTemperature(temp, lambda);
+  }
+
  private:
   Real kappa_; // Opacity. Units of cm^2/g
   PlanckDistribution dist_;

--- a/singularity-opac/photons/non_cgs_photons.hpp
+++ b/singularity-opac/photons/non_cgs_photons.hpp
@@ -187,6 +187,28 @@ class NonCGSUnits {
     return NoH * mass_unit_ / rho_unit_ * time_unit_ / length_unit_;
   }
 
+  PORTABLE_INLINE_FUNCTION
+  Real EnergyDensityFromTemperature(const Real temp,
+                                    Real *lambda = nullptr) const {
+    Real BoH = opac_.EnergyDensityFromTemperature(temp * temp_unit_, lambda);
+    return BoH * inv_energy_dens_unit_;
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real TemperatureFromEnergyDensity(const Real er,
+                                    Real *lambda = nullptr) const {
+    Real BoH =
+        opac_.TemperatureFromEnergyDensity(er / inv_energy_dens_unit_, lambda);
+    return BoH / temp_unit_;
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real NumberDensityFromTemperature(const Real temp,
+                                    Real *lambda = nullptr) const {
+    Real NoH = opac_.NumberDensityFromTemperature(temp * temp_unit_, lambda);
+    return NoH * mass_unit_ / rho_unit_;
+  }
+
  private:
   Opac opac_;
   Real time_unit_, mass_unit_, length_unit_, temp_unit_;

--- a/singularity-opac/photons/photon_variant.hpp
+++ b/singularity-opac/photons/photon_variant.hpp
@@ -200,7 +200,7 @@ class Variant {
         opac_);
   }
 
-  // Energy density of thermal distribution
+  // Integral of thermal distribution over frequency and angle
   PORTABLE_INLINE_FUNCTION Real
   ThermalDistributionOfT(const Real temp, Real *lambda = nullptr) const {
     return mpark::visit(
@@ -210,12 +210,42 @@ class Variant {
         opac_);
   }
 
-  // Number density of thermal distribution
+  // Integral of thermal distribution over energy per frequency and angle
   PORTABLE_INLINE_FUNCTION Real
   ThermalNumberDistributionOfT(const Real temp, Real *lambda = nullptr) const {
     return mpark::visit(
         [=](const auto &opac) {
           return opac.ThermalNumberDistributionOfT(temp, lambda);
+        },
+        opac_);
+  }
+
+  // Energy density of thermal distribution
+  PORTABLE_INLINE_FUNCTION Real
+  EnergyDensityFromTemperature(const Real temp, Real *lambda = nullptr) const {
+    return mpark::visit(
+        [=](const auto &opac) {
+          return opac.EnergyDensityFromTemperature(temp, lambda);
+        },
+        opac_);
+  }
+
+  // Temperature of thermal distribution
+  PORTABLE_INLINE_FUNCTION Real
+  TemperatureFromEnergyDensity(const Real er, Real *lambda = nullptr) const {
+    return mpark::visit(
+        [=](const auto &opac) {
+          return opac.TemperatureFromEnergyDensity(er, lambda);
+        },
+        opac_);
+  }
+
+  // Number density of thermal distribution
+  PORTABLE_INLINE_FUNCTION Real
+  NumberDensityFromTemperature(const Real temp, Real *lambda = nullptr) const {
+    return mpark::visit(
+        [=](const auto &opac) {
+          return opac.NumberDensityFromTemperature(temp, lambda);
         },
         opac_);
   }

--- a/singularity-opac/photons/thermal_distributions_photons.hpp
+++ b/singularity-opac/photons/thermal_distributions_photons.hpp
@@ -48,6 +48,23 @@ struct PlanckDistribution {
     return 16. * pow(pc::kb, 3) * M_PI * pow(temp, 3) * zeta3 /
            (pow(pc::c, 2) * pow(pc::h, 3));
   }
+  PORTABLE_INLINE_FUNCTION
+  Real EnergyDensityFromTemperature(const Real temp,
+                                    Real *lambda = nullptr) const {
+    return ThermalDistributionOfT(temp, lambda) / pc::c;
+  }
+  PORTABLE_INLINE_FUNCTION
+  Real TemperatureFromEnergyDensity(const Real er,
+                                    Real *lambda = nullptr) const {
+    return pow(15. * std::pow(pc::c, 2) * std::pow(pc::h, 3) * er /
+                   (8. * std::pow(M_PI, 5) * std::pow(pc::kb, 4)),
+               1. / 4.);
+  }
+  PORTABLE_INLINE_FUNCTION
+  Real NumberDensityFromTemperature(const Real temp,
+                                    Real *lambda = nullptr) const {
+    return ThermalNumberDistributionOfT(temp, lambda) / pc::c;
+  }
   template <typename Emissivity>
   PORTABLE_INLINE_FUNCTION Real AbsorptionCoefficientFromKirkhoff(
       const Emissivity &J, const Real rho, const Real temp, const Real nu,

--- a/singularity-opac/photons/thermal_distributions_photons.hpp
+++ b/singularity-opac/photons/thermal_distributions_photons.hpp
@@ -56,7 +56,7 @@ struct PlanckDistribution {
   PORTABLE_INLINE_FUNCTION
   Real TemperatureFromEnergyDensity(const Real er,
                                     Real *lambda = nullptr) const {
-    return pow(15. * std::pow(pc::c, 2) * std::pow(pc::h, 3) * er /
+    return pow(15. * std::pow(pc::c, 3) * std::pow(pc::h, 3) * er /
                    (8. * std::pow(M_PI, 5) * std::pow(pc::kb, 4)),
                1. / 4.);
   }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -35,6 +35,7 @@ add_executable(${PROJECT_NAME}_unit_tests)
 target_sources(${PROJECT_NAME}_unit_tests
 PRIVATE
   test_trivial.cpp
+  test_thermal_dist.cpp
   test_gray_opacities.cpp
   test_brt_opacities.cpp
   test_chebyshev.cpp

--- a/test/test_thermal_dist.cpp
+++ b/test/test_thermal_dist.cpp
@@ -47,6 +47,7 @@ TEST_CASE("Neutrino thermal distribution", "[NeutrinoThermalDistribution]") {
   WHEN("We initialize a gray neutrino opacity") {
     constexpr Real MeV2K = 1e6 * pc::eV / pc::kb;
     constexpr Real temp = 10 * MeV2K; // 10 MeV
+    constexpr RadiationType type = RadiationType::NU_ELECTRON;
 
     neutrinos::Gray opac_host(1);
     neutrinos::Opacity opac = opac_host.GetOnDevice();

--- a/test/test_thermal_dist.cpp
+++ b/test/test_thermal_dist.cpp
@@ -102,9 +102,9 @@ TEST_CASE("Photon thermal distribution", "[PhotonThermalDistribution]") {
       portableFor(
           "calc temperatures", 0, 100, PORTABLE_LAMBDA(const int &i) {
             Real Tr0 = (1. + 0.01 * i) * temp;
-            Real er = opac.EnergyDensityFromTemperature(Tr0, type);
-            Real B = opac.ThermalDistributionOfT(Tr0, type);
-            Real Tr = opac.TemperatureFromEnergyDensity(er, type);
+            Real er = opac.EnergyDensityFromTemperature(Tr0);
+            Real B = opac.ThermalDistributionOfT(Tr0);
+            Real Tr = opac.TemperatureFromEnergyDensity(er);
             if (FractionalDifference(er, B / pc::c) > EPS_TEST) {
               n_wrong_d() += 1;
             }

--- a/test/test_thermal_dist.cpp
+++ b/test/test_thermal_dist.cpp
@@ -1,0 +1,123 @@
+// ======================================================================
+// © 2022. Triad National Security, LLC. All rights reserved.  This
+// program was produced under U.S. Government contract
+// 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
+// is operated by Triad National Security, LLC for the U.S.
+// Department of Energy/National Nuclear Security Administration. All
+// rights in the program are reserved by Triad National Security, LLC,
+// and the U.S. Department of Energy/National Nuclear Security
+// Administration. The Government is granted for itself and others
+// acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works,
+// distribute copies to the public, perform publicly and display
+// publicly, and to permit others to do so.
+// ======================================================================
+
+#include <cmath>
+#include <iostream>
+
+#include <catch2/catch.hpp>
+
+#include <ports-of-call/portability.hpp>
+#include <ports-of-call/portable_arrays.hpp>
+#include <spiner/databox.hpp>
+
+#include <singularity-opac/base/indexers.hpp>
+#include <singularity-opac/base/radiation_types.hpp>
+#include <singularity-opac/chebyshev/chebyshev.hpp>
+#include <singularity-opac/constants/constants.hpp>
+#include <singularity-opac/neutrinos/opac_neutrinos.hpp>
+#include <singularity-opac/photons/opac_photons.hpp>
+
+using namespace singularity;
+
+using pc = PhysicalConstants<CGS>;
+
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+using atomic_view = Kokkos::MemoryTraits<Kokkos::Atomic>;
+#endif
+
+template <typename T>
+PORTABLE_INLINE_FUNCTION T FractionalDifference(const T &a, const T &b) {
+  return 2 * std::abs(b - a) / (std::abs(a) + std::abs(b) + 1e-20);
+}
+constexpr Real EPS_TEST = 1e-3;
+
+TEST_CASE("Neutrino thermal distribution", "[NeutrinoThermalDistribution]") {
+  WHEN("We initialize a gray neutrino opacity") {
+    constexpr Real MeV2K = 1e6 * pc::eV / pc::kb;
+    constexpr Real temp = 10 * MeV2K; // 10 MeV
+
+    neutrinos::Gray opac_host(1);
+    neutrinos::Opacity opac = opac_host.GetOnDevice();
+
+    THEN("The energy density of temperature is consistent with the temperature "
+         "of energy density") {
+      int n_wrong_h = 0;
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+      Kokkos::View<int, atomic_view> n_wrong_d("wrong");
+#else
+      PortableMDArray<int> n_wrong_d(&n_wrong_h, 1);
+#endif
+      portableFor(
+          "calc temperatures", 0, 100, PORTABLE_LAMBDA(const int &i) {
+            Real Tr0 = (1. + 0.01 * i) * temp;
+            Real er = opac.EnergyDensityFromTemperature(Tr0, type);
+            Real B = opac.ThermalDistributionOfT(Tr0, type);
+            Real Tr = opac.TemperatureFromEnergyDensity(er, type);
+            if (FractionalDifference(er, B / pc::c) > EPS_TEST) {
+              n_wrong_d() += 1;
+            }
+            if (FractionalDifference(Tr0, Tr) > EPS_TEST) {
+              n_wrong_d() += 1;
+            }
+          });
+
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+      Kokkos::deep_copy(n_wrong_h, n_wrong_d);
+#endif
+      REQUIRE(n_wrong_h == 0);
+    }
+
+    opac.Finalize();
+  }
+}
+
+TEST_CASE("Photon thermal distribution", "[PhotonThermalDistribution]") {
+  WHEN("We initialize a gray photon opacity") {
+    constexpr Real temp = 1.e6;
+
+    neutrinos::Gray opac_host(1);
+    neutrinos::Opacity opac = opac_host.GetOnDevice();
+
+    THEN("The energy density of temperature is consistent with the temperature "
+         "of energy density") {
+      int n_wrong_h = 0;
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+      Kokkos::View<int, atomic_view> n_wrong_d("wrong");
+#else
+      PortableMDArray<int> n_wrong_d(&n_wrong_h, 1);
+#endif
+      portableFor(
+          "calc temperatures", 0, 100, PORTABLE_LAMBDA(const int &i) {
+            Real Tr0 = (1. + 0.01 * i) * temp;
+            Real er = opac.EnergyDensityFromTemperature(Tr0, type);
+            Real B = opac.ThermalDistributionOfT(Tr0, type);
+            Real Tr = opac.TemperatureFromEnergyDensity(er, type);
+            if (FractionalDifference(er, B / pc::c) > EPS_TEST) {
+              n_wrong_d() += 1;
+            }
+            if (FractionalDifference(Tr0, Tr) > EPS_TEST) {
+              n_wrong_d() += 1;
+            }
+          });
+
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+      Kokkos::deep_copy(n_wrong_h, n_wrong_d);
+#endif
+      REQUIRE(n_wrong_h == 0);
+    }
+
+    opac.Finalize();
+  }
+}

--- a/test/test_thermal_dist.cpp
+++ b/test/test_thermal_dist.cpp
@@ -88,8 +88,8 @@ TEST_CASE("Photon thermal distribution", "[PhotonThermalDistribution]") {
   WHEN("We initialize a gray photon opacity") {
     constexpr Real temp = 1.e6;
 
-    neutrinos::Gray opac_host(1);
-    neutrinos::Opacity opac = opac_host.GetOnDevice();
+    photons::Gray opac_host(1);
+    photons::Opacity opac = opac_host.GetOnDevice();
 
     THEN("The energy density of temperature is consistent with the temperature "
          "of energy density") {


### PR DESCRIPTION
This PR adds `EnergyDensityFromTemperature`, `TemperatureFromEnergyDensity`, and `NumberDensityFromTemperature` calls to photon and neutrino thermal distributions (and loops the calls through the opacities themselves. Downstream, it turns out that having to convert between e.g. `B` and `Er` is tedious because if you aren't in cgs units you need the speed of light in code units. Also, the only way to calculate temperature from the radiation energy downstream was with a rootfind over `ThermalDistributionOfT` which is wasteful. 

I also added a simple unit test for some of these calls. 