### PR TITLE
Turn mean opacity into a variant

### DIFF
--- a/singularity-opac/neutrinos/mean_neutrino_variant.hpp
+++ b/singularity-opac/neutrinos/mean_neutrino_variant.hpp
@@ -1,0 +1,100 @@
+// ======================================================================
+// © 2021. Triad National Security, LLC. All rights reserved.  This
+// program was produced under U.S. Government contract
+// 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
+// is operated by Triad National Security, LLC for the U.S.
+// Department of Energy/National Nuclear Security Administration. All
+// rights in the program are reserved by Triad National Security, LLC,
+// and the U.S. Department of Energy/National Nuclear Security
+// Administration. The Government is granted for itself and others
+// acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works,
+// distribute copies to the public, perform publicly and display
+// publicly, and to permit others to do so.
+// ======================================================================
+
+#ifndef SINGULARITY_OPAC_NEUTRINOS_MEAN_NEUTRINO_VARIANT_
+#define SINGULARITY_OPAC_NEUTRINOS_MEAN_NEUTRINO_VARIANT_
+
+#include <utility>
+
+#include <ports-of-call/portability.hpp>
+#include <singularity-opac/base/opac_error.hpp>
+#include <singularity-opac/base/radiation_types.hpp>
+#include <singularity-opac/neutrinos/neutrino_variant.hpp>
+#include <variant/include/mpark/variant.hpp>
+
+namespace singularity {
+namespace neutrinos {
+namespace impl {
+
+template <typename... Opacs>
+class MeanVariant {
+ private:
+  opac_variant<Opacs...> opac_;
+
+ public:
+  template <
+      typename Choice,
+      typename std::enable_if<
+          !std::is_same<MeanVariant, typename std::decay<Choice>::type>::value,
+          bool>::type = true>
+  PORTABLE_FUNCTION MeanVariant(Choice &&choice)
+      : opac_(std::forward<Choice>(choice)) {}
+
+  PORTABLE_FUNCTION
+  MeanVariant() noexcept = default;
+
+  template <
+      typename Choice,
+      typename std::enable_if<
+          !std::is_same<MeanVariant, typename std::decay<Choice>::type>::value,
+          bool>::type = true>
+  PORTABLE_FUNCTION MeanVariant &operator=(Choice &&opac) {
+    opac_ = std::forward<Choice>(opac);
+    return *this;
+  }
+
+  template <
+      typename Choice,
+      typename std::enable_if<
+          !std::is_same<MeanVariant, typename std::decay<Choice>::type>::value,
+          bool>::type = true>
+  Choice get() {
+    return mpark::get<Choice>(opac_);
+  }
+
+  MeanVariant GetOnDevice() {
+    return mpark::visit(
+        [](auto &opac) { return opac_variant<Opacs...>(opac.GetOnDevice()); },
+        opac_);
+  }
+
+  PORTABLE_INLINE_FUNCTION Real PlanckMeanAbsorptionCoefficient(
+      const Real rho, const Real temp, const Real Ye, const RadiationType type) const {
+    return mpark::visit(
+        [=](const auto &opac) {
+          return opac.PlanckMeanAbsorptionCoefficient(rho, temp, Ye, type);
+        },
+        opac_);
+  }
+  PORTABLE_INLINE_FUNCTION Real RosselandMeanAbsorptionCoefficient(
+      const Real rho, const Real temp, const Real Ye, const RadiationType type) const {
+    return mpark::visit(
+        [=](const auto &opac) {
+          return opac.RosselandMeanAbsorptionCoefficient(rho, temp, Ye, type);
+        },
+        opac_);
+  }
+
+  inline void Finalize() noexcept {
+    return mpark::visit([](auto &opac) { return opac.Finalize(); }, opac_);
+  }
+
+};
+
+} // impl
+}
+}
+
+#endif // SINGULARITY_OPAC_NEUTRINOS_MEAN_NEUTRINO_VARIANT_

--- a/singularity-opac/neutrinos/mean_opacity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/mean_opacity_neutrinos.hpp
@@ -35,13 +35,13 @@ namespace neutrinos {
 // temperatures, and Ye
 
 template <typename pc = PhysicalConstantsCGS>
-class MeanOpacity {
+class MeanOpacityImpl {
  public:
-  MeanOpacity() = default;
+  MeanOpacityImpl() = default;
   template <typename Opacity>
-  MeanOpacity(const Opacity &opac, Real lRhoMin, Real lRhoMax, int NRho,
-              Real lTMin, Real lTMax, int NT, Real YeMin, Real YeMax, int NYe,
-              Real *lambda = nullptr) {
+  MeanOpacityImpl(const Opacity &opac, Real lRhoMin, Real lRhoMax, int NRho,
+                  Real lTMin, Real lTMax, int NT, Real YeMin, Real YeMax,
+                  int NYe, Real *lambda = nullptr) {
     lkappaPlanck_.resize(NRho, NT, NYe, NEUTRINO_NTYPES);
     // index 0 is the species and is not interpolatable
     lkappaPlanck_.setRange(1, YeMin, YeMax, NYe);
@@ -133,7 +133,7 @@ class MeanOpacity {
   }
 
 #ifdef SPINER_USE_HDF
-  MeanOpacity(const std::string &filename) : filename_(filename.c_str()) {
+  MeanOpacityImpl(const std::string &filename) : filename_(filename.c_str()) {
     herr_t status = H5_SUCCESS;
     hid_t file = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
     status += lkappaPlanck_.loadHDF(file, SP5::MeanOpac::PlanckMeanOpacity);
@@ -165,8 +165,8 @@ class MeanOpacity {
     printf("Mean opacity\n");
   }
 
-  MeanOpacity GetOnDevice() {
-    MeanOpacity other;
+  MeanOpacityImpl GetOnDevice() {
+    MeanOpacityImpl other;
     other.lkappaPlanck_ = Spiner::getOnDeviceDataBox(lkappaPlanck_);
     other.lkappaRosseland_ = Spiner::getOnDeviceDataBox(lkappaRosseland_);
     return other;
@@ -211,9 +211,9 @@ class MeanOpacity {
 
 #undef EPS
 
-using MeanScaleFree = MeanOpacity<PhysicalConstantsUnity>;
-using MeanCGS = MeanOpacity<PhysicalConstantsCGS>;
-using VMeanOpacity = impl::MeanVariant<MeanScaleFree, MeanCGS>;
+using MeanOpacityScaleFree = MeanOpacityImpl<PhysicalConstantsUnity>;
+using MeanOpacityCGS = MeanOpacityImpl<PhysicalConstantsCGS>;
+using MeanOpacity = impl::MeanVariant<MeanOpacityScaleFree, MeanOpacityCGS>;
 
 } // namespace neutrinos
 } // namespace singularity

--- a/singularity-opac/neutrinos/mean_opacity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/mean_opacity_neutrinos.hpp
@@ -28,6 +28,7 @@
 
 namespace singularity {
 namespace neutrinos {
+namespace impl {
 
 #define EPS (10.0 * std::numeric_limits<Real>::min())
 
@@ -35,14 +36,14 @@ namespace neutrinos {
 // temperatures, and Ye
 
 template <typename pc = PhysicalConstantsCGS>
-class MeanOpacityImpl {
+class MeanOpacity {
  public:
-  MeanOpacityImpl() = default;
+  MeanOpacity() = default;
   template <typename Opacity>
-  MeanOpacityImpl(const Opacity &opac, const Real lRhoMin, const Real lRhoMax,
-                  const int NRho, const Real lTMin, const Real lTMax,
-                  const int NT, const Real YeMin, const Real YeMax,
-                  const int NYe, Real *lambda = nullptr) {
+  MeanOpacity(const Opacity &opac, const Real lRhoMin, const Real lRhoMax,
+              const int NRho, const Real lTMin, const Real lTMax, const int NT,
+              const Real YeMin, const Real YeMax, const int NYe,
+              Real *lambda = nullptr) {
     lkappaPlanck_.resize(NRho, NT, NYe, NEUTRINO_NTYPES);
     // index 0 is the species and is not interpolatable
     lkappaPlanck_.setRange(1, YeMin, YeMax, NYe);
@@ -134,7 +135,7 @@ class MeanOpacityImpl {
   }
 
 #ifdef SPINER_USE_HDF
-  MeanOpacityImpl(const std::string &filename) : filename_(filename.c_str()) {
+  MeanOpacity(const std::string &filename) : filename_(filename.c_str()) {
     herr_t status = H5_SUCCESS;
     hid_t file = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
     status += lkappaPlanck_.loadHDF(file, SP5::MeanOpac::PlanckMeanOpacity);
@@ -166,8 +167,8 @@ class MeanOpacityImpl {
     printf("Mean opacity\n");
   }
 
-  MeanOpacityImpl GetOnDevice() {
-    MeanOpacityImpl other;
+  MeanOpacity GetOnDevice() {
+    MeanOpacity other;
     other.lkappaPlanck_ = Spiner::getOnDeviceDataBox(lkappaPlanck_);
     other.lkappaRosseland_ = Spiner::getOnDeviceDataBox(lkappaRosseland_);
     return other;
@@ -212,8 +213,10 @@ class MeanOpacityImpl {
 
 #undef EPS
 
-using MeanOpacityScaleFree = MeanOpacityImpl<PhysicalConstantsUnity>;
-using MeanOpacityCGS = MeanOpacityImpl<PhysicalConstantsCGS>;
+} // namespace impl
+
+using MeanOpacityScaleFree = impl::MeanOpacity<PhysicalConstantsUnity>;
+using MeanOpacityCGS = impl::MeanOpacity<PhysicalConstantsCGS>;
 using MeanOpacity = impl::MeanVariant<MeanOpacityScaleFree, MeanOpacityCGS>;
 
 } // namespace neutrinos

--- a/singularity-opac/neutrinos/mean_opacity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/mean_opacity_neutrinos.hpp
@@ -85,18 +85,6 @@ class MeanOpacity {
                   opac.DThermalDistributionOfTNuDT(T, type, nu) * nu * dlnu;
               kappaRosselandDenom +=
                   opac.DThermalDistributionOfTNuDT(T, type, nu) * nu * dlnu;
-
-              printf(
-                  "a: %e d: %e %e %e %e\n",
-                  opac.AbsorptionCoefficient(rho, T, Ye, type, nu, lambda),
-                  opac.AbsorptionCoefficient(rho, T, Ye, type, nu, lambda) /
-                      rho * opac.ThermalDistributionOfTNu(T, type, nu) * nu *
-                      dlnu,
-                  opac.ThermalDistributionOfTNu(T, type, nu) * nu * dlnu,
-                  rho /
-                      opac.AbsorptionCoefficient(rho, T, Ye, type, nu, lambda) *
-                      opac.DThermalDistributionOfTNuDT(T, type, nu) * nu * dlnu,
-                  opac.DThermalDistributionOfTNuDT(T, type, nu) * nu * dlnu);
             }
 
             // Trapezoidal rule
@@ -134,9 +122,6 @@ class MeanOpacity {
                 toLog_(1. / (kappaRosselandNum / kappaRosselandDenom));
             lkappaPlanck_(iRho, iT, iYe, idx) = lkappaPlanck;
             lkappaRosseland_(iRho, iT, iYe, idx) = lkappaRosseland;
-            printf("[%i %i %i %i] = %e %e\n", iRho, iT, iYe, idx,
-                   lkappaPlanck_(iRho, iT, iYe, idx),
-                   lkappaRosseland_(iRho, iT, iYe, idx));
             if (std::isnan(lkappaPlanck_(iRho, iT, iYe, idx)) ||
                 std::isnan(lkappaRosseland_(iRho, iT, iYe, idx))) {
               OPAC_ERROR("neutrinos::MeanOpacity: NAN in opacity evaluations");

--- a/singularity-opac/neutrinos/mean_opacity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/mean_opacity_neutrinos.hpp
@@ -39,9 +39,10 @@ class MeanOpacityImpl {
  public:
   MeanOpacityImpl() = default;
   template <typename Opacity>
-  MeanOpacityImpl(const Opacity &opac, Real lRhoMin, Real lRhoMax, int NRho,
-                  Real lTMin, Real lTMax, int NT, Real YeMin, Real YeMax,
-                  int NYe, Real *lambda = nullptr) {
+  MeanOpacityImpl(const Opacity &opac, const Real lRhoMin, const Real lRhoMax,
+                  const int NRho, const Real lTMin, const Real lTMax,
+                  const int NT, const Real YeMin, const Real YeMax,
+                  const int NYe, Real *lambda = nullptr) {
     lkappaPlanck_.resize(NRho, NT, NYe, NEUTRINO_NTYPES);
     // index 0 is the species and is not interpolatable
     lkappaPlanck_.setRange(1, YeMin, YeMax, NYe);

--- a/singularity-opac/neutrinos/opac_neutrinos.hpp
+++ b/singularity-opac/neutrinos/opac_neutrinos.hpp
@@ -26,6 +26,8 @@
 #include <singularity-opac/neutrinos/thermal_distributions_neutrinos.hpp>
 #include <singularity-opac/neutrinos/tophat_emissivity_neutrinos.hpp>
 
+#include <singularity-opac/neutrinos/mean_opacity_neutrinos.hpp>
+
 namespace singularity {
 namespace neutrinos {
 

--- a/singularity-opac/neutrinos/thermal_distributions_neutrinos.hpp
+++ b/singularity-opac/neutrinos/thermal_distributions_neutrinos.hpp
@@ -33,8 +33,6 @@ struct FermiDiracDistributionNoMu {
   Real ThermalDistributionOfTNu(const Real temp, const RadiationType type,
                                 const Real nu, Real *lambda = nullptr) const {
     Real x = pc::h * nu / (pc::kb * temp);
-    printf("x: %e h: %e nu: %e kb: %e temp: %e\n",
-      x, pc::h, nu, pc::kb, temp);
     Real Bnu = NSPECIES * (2. * pc::h * nu * nu * nu / (pc::c * pc::c)) * 1. /
                (std::exp(x) + 1.);
     return Bnu;

--- a/singularity-opac/neutrinos/thermal_distributions_neutrinos.hpp
+++ b/singularity-opac/neutrinos/thermal_distributions_neutrinos.hpp
@@ -33,6 +33,8 @@ struct FermiDiracDistributionNoMu {
   Real ThermalDistributionOfTNu(const Real temp, const RadiationType type,
                                 const Real nu, Real *lambda = nullptr) const {
     Real x = pc::h * nu / (pc::kb * temp);
+    printf("x: %e h: %e nu: %e kb: %e temp: %e\n",
+      x, pc::h, nu, pc::kb, temp);
     Real Bnu = NSPECIES * (2. * pc::h * nu * nu * nu / (pc::c * pc::c)) * 1. /
                (std::exp(x) + 1.);
     return Bnu;

--- a/test/test_mean_opacities.cpp
+++ b/test/test_mean_opacities.cpp
@@ -81,8 +81,9 @@ TEST_CASE("Mean neutrino opacities", "[MeanNeutrinos]") {
     neutrinos::Gray opac_host(kappa);
     neutrinos::Opacity opac = opac_host.GetOnDevice();
 
-    neutrinos::MeanOpacity<pc> mean_opac_host(
+    neutrinos::MeanOpacityCGS mean_opac_host(
         opac_host, lRhoMin, lRhoMax, NRho, lTMin, lTMax, NT, YeMin, YeMax, NYe);
+    // neutrinos::MeanOpacity mean_opac = mean_opac_host.GetOnDevice();
     auto mean_opac = mean_opac_host.GetOnDevice();
 
     THEN("The emissivity per nu omega is consistent with the emissity per nu") {
@@ -116,7 +117,7 @@ TEST_CASE("Mean neutrino opacities", "[MeanNeutrinos]") {
 #ifdef SPINER_USE_HDF
     THEN("We can save to disk and reload") {
       mean_opac.Save(grayname);
-      neutrinos::MeanOpacity<pc> mean_opac_host_load(grayname);
+      neutrinos::MeanOpacityCGS mean_opac_host_load(grayname);
       AND_THEN("The reloaded table matches the gray opacities") {
 
         auto mean_opac_load = mean_opac_host_load.GetOnDevice();
@@ -169,9 +170,9 @@ TEST_CASE("Mean neutrino opacities", "[MeanNeutrinos]") {
           mass_unit / (length_unit * length_unit * length_unit);
 
       auto funny_units_host =
-          neutrinos::MeanNonCGSUnits<neutrinos::MeanOpacity<pc>>(
-              std::forward<neutrinos::MeanOpacity<pc>>(mean_opac_host),
-              time_unit, mass_unit, length_unit, temp_unit);
+          neutrinos::MeanNonCGSUnits<neutrinos::MeanOpacity>(
+              std::forward<neutrinos::MeanOpacity>(mean_opac_host), time_unit,
+              mass_unit, length_unit, temp_unit);
 
       auto funny_units = funny_units_host.GetOnDevice();
 


### PR DESCRIPTION
There were some hardcoded cgs numbers in the mean opacity constructor. I fixed that and also turned mean opacity into a variant since it's annoying to use downstream otherwise.