### PR TITLE
Add mean opacity for photons

### DIFF
--- a/singularity-opac/base/robust_utils.hpp
+++ b/singularity-opac/base/robust_utils.hpp
@@ -18,40 +18,40 @@
 #include <limits>
 #include <ports-of-call/portability.hpp>
 
-namespace singularity {
-namespace robust {
+namespace singularity - opac {
+  namespace robust {
 
-template <typename T = Real>
-PORTABLE_FORCEINLINE_FUNCTION constexpr auto SMALL() {
-  return 10 * std::numeric_limits<T>::min();
-}
+  template <typename T = Real>
+  PORTABLE_FORCEINLINE_FUNCTION constexpr auto SMALL() {
+    return 10 * std::numeric_limits<T>::min();
+  }
 
-template <typename T = Real>
-PORTABLE_FORCEINLINE_FUNCTION constexpr auto EPS() {
-  return 10 * std::numeric_limits<T>::epsilon();
-}
+  template <typename T = Real>
+  PORTABLE_FORCEINLINE_FUNCTION constexpr auto EPS() {
+    return 10 * std::numeric_limits<T>::epsilon();
+  }
 
-template <typename T>
-PORTABLE_FORCEINLINE_FUNCTION auto make_positive(const T val) {
-  return std::max(val, EPS<T>());
-}
+  template <typename T>
+  PORTABLE_FORCEINLINE_FUNCTION auto make_positive(const T val) {
+    return std::max(val, EPS<T>());
+  }
 
-PORTABLE_FORCEINLINE_FUNCTION
-Real make_bounded(const Real val, const Real vmin, const Real vmax) {
-  return std::min(std::max(val, vmin + EPS()), vmax * (1.0 - EPS()));
-}
+  PORTABLE_FORCEINLINE_FUNCTION
+  Real make_bounded(const Real val, const Real vmin, const Real vmax) {
+    return std::min(std::max(val, vmin + EPS()), vmax * (1.0 - EPS()));
+  }
 
-template <typename T>
-PORTABLE_FORCEINLINE_FUNCTION int sgn(const T &val) {
-  return (T(0) <= val) - (val < T(0));
-}
+  template <typename T>
+  PORTABLE_FORCEINLINE_FUNCTION int sgn(const T &val) {
+    return (T(0) <= val) - (val < T(0));
+  }
 
-template <typename A, typename B>
-PORTABLE_FORCEINLINE_FUNCTION auto ratio(const A &a, const B &b) {
-  return a / (b + sgn(b) * SMALL<B>());
-}
+  template <typename A, typename B>
+  PORTABLE_FORCEINLINE_FUNCTION auto ratio(const A &a, const B &b) {
+    return a / (b + sgn(b) * SMALL<B>());
+  }
 
-} // namespace robust
-} // namespace singularity
+  } // namespace robust
+} // namespace opac
 
 #endif // SINGULARITY_OPAC_BASE_ROBUST_UTILS_HPP_

--- a/singularity-opac/base/robust_utils.hpp
+++ b/singularity-opac/base/robust_utils.hpp
@@ -1,0 +1,57 @@
+//------------------------------------------------------------------------------
+// © 2021-2022. Triad National Security, LLC. All rights reserved.  This
+// program was produced under U.S. Government contract 89233218CNA000001
+// for Los Alamos National Laboratory (LANL), which is operated by Triad
+// National Security, LLC for the U.S.  Department of Energy/National
+// Nuclear Security Administration. All rights in the program are
+// reserved by Triad National Security, LLC, and the U.S. Department of
+// Energy/National Nuclear Security Administration. The Government is
+// granted for itself and others acting on its behalf a nonexclusive,
+// paid-up, irrevocable worldwide license in this material to reproduce,
+// prepare derivative works, distribute copies to the public, perform
+// publicly and display publicly, and to permit others to do so.
+//------------------------------------------------------------------------------
+
+#ifndef SINGULARITY_OPAC_BASE_ROBUST_UTILS_HPP_
+#define SINGULARITY_OPAC_BASE_ROBUST_UTILS_HPP_
+
+#include <limits>
+#include <ports-of-call/portability.hpp>
+
+namespace singularity {
+namespace robust {
+
+template <typename T = Real>
+PORTABLE_FORCEINLINE_FUNCTION constexpr auto SMALL() {
+  return 10 * std::numeric_limits<T>::min();
+}
+
+template <typename T = Real>
+PORTABLE_FORCEINLINE_FUNCTION constexpr auto EPS() {
+  return 10 * std::numeric_limits<T>::epsilon();
+}
+
+template <typename T>
+PORTABLE_FORCEINLINE_FUNCTION auto make_positive(const T val) {
+  return std::max(val, EPS<T>());
+}
+
+PORTABLE_FORCEINLINE_FUNCTION
+Real make_bounded(const Real val, const Real vmin, const Real vmax) {
+  return std::min(std::max(val, vmin + EPS()), vmax * (1.0 - EPS()));
+}
+
+template <typename T>
+PORTABLE_FORCEINLINE_FUNCTION int sgn(const T &val) {
+  return (T(0) <= val) - (val < T(0));
+}
+
+template <typename A, typename B>
+PORTABLE_FORCEINLINE_FUNCTION auto ratio(const A &a, const B &b) {
+  return a / (b + sgn(b) * SMALL<B>());
+}
+
+} // namespace robust
+} // namespace singularity
+
+#endif // SINGULARITY_OPAC_BASE_ROBUST_UTILS_HPP_

--- a/singularity-opac/base/robust_utils.hpp
+++ b/singularity-opac/base/robust_utils.hpp
@@ -18,7 +18,7 @@
 #include <limits>
 #include <ports-of-call/portability.hpp>
 
-namespace singularity - opac {
+namespace singularity_opac {
   namespace robust {
 
   template <typename T = Real>
@@ -52,6 +52,6 @@ namespace singularity - opac {
   }
 
   } // namespace robust
-} // namespace opac
+} // namespace singularity_opac
 
 #endif // SINGULARITY_OPAC_BASE_ROBUST_UTILS_HPP_

--- a/singularity-opac/neutrinos/thermal_distributions_neutrinos.hpp
+++ b/singularity-opac/neutrinos/thermal_distributions_neutrinos.hpp
@@ -20,6 +20,7 @@
 
 #include <ports-of-call/portability.hpp>
 #include <singularity-opac/base/radiation_types.hpp>
+#include <singularity-opac/base/robust_utils.hpp>
 #include <singularity-opac/constants/constants.hpp>
 
 namespace singularity {
@@ -87,7 +88,7 @@ struct FermiDiracDistributionNoMu {
         std::max(ThermalDistributionOfTNu(temp, type, nu, lambda), EPS);
     const Real jnu =
         std::max(J.EmissivityPerNuOmega(rho, temp, Ye, type, nu, lambda), EPS);
-    return jnu / Bnu;
+    return robust::ratio(jnu, Bnu);
   }
   template <typename Emissivity>
   PORTABLE_INLINE_FUNCTION Real AngleAveragedAbsorptionCoefficientFromKirkhoff(
@@ -98,7 +99,7 @@ struct FermiDiracDistributionNoMu {
     const Real jnu =
         std::max(J.EmissivityPerNu(rho, temp, Ye, type, nu, lambda), EPS) /
         (4. * M_PI);
-    return jnu / Bnu;
+    return robust::ratio(jnu, Bnu);
   }
 };
 

--- a/singularity-opac/neutrinos/thermal_distributions_neutrinos.hpp
+++ b/singularity-opac/neutrinos/thermal_distributions_neutrinos.hpp
@@ -26,8 +26,6 @@
 namespace singularity {
 namespace neutrinos {
 
-using namespace singularity - opac;
-
 #define EPS (10.0 * std::numeric_limits<Real>::min())
 
 template <int NSPECIES, typename pc = PhysicalConstantsCGS>
@@ -90,7 +88,7 @@ struct FermiDiracDistributionNoMu {
         std::max(ThermalDistributionOfTNu(temp, type, nu, lambda), EPS);
     const Real jnu =
         std::max(J.EmissivityPerNuOmega(rho, temp, Ye, type, nu, lambda), EPS);
-    return robust::ratio(jnu, Bnu);
+    return singularity_opac::robust::ratio(jnu, Bnu);
   }
   template <typename Emissivity>
   PORTABLE_INLINE_FUNCTION Real AngleAveragedAbsorptionCoefficientFromKirkhoff(
@@ -101,7 +99,7 @@ struct FermiDiracDistributionNoMu {
     const Real jnu =
         std::max(J.EmissivityPerNu(rho, temp, Ye, type, nu, lambda), EPS) /
         (4. * M_PI);
-    return robust::ratio(jnu, Bnu);
+    return singularity_opac::robust::ratio(jnu, Bnu);
   }
 };
 

--- a/singularity-opac/neutrinos/thermal_distributions_neutrinos.hpp
+++ b/singularity-opac/neutrinos/thermal_distributions_neutrinos.hpp
@@ -26,6 +26,8 @@
 namespace singularity {
 namespace neutrinos {
 
+using namespace singularity - opac;
+
 #define EPS (10.0 * std::numeric_limits<Real>::min())
 
 template <int NSPECIES, typename pc = PhysicalConstantsCGS>

--- a/singularity-opac/photons/mean_opacity_photons.hpp
+++ b/singularity-opac/photons/mean_opacity_photons.hpp
@@ -20,6 +20,7 @@
 
 #include <ports-of-call/portability.hpp>
 #include <singularity-opac/base/radiation_types.hpp>
+#include <singularity-opac/base/robust_utils.hpp>
 #include <singularity-opac/base/sp5.hpp>
 #include <singularity-opac/constants/constants.hpp>
 #include <spiner/databox.hpp>
@@ -37,6 +38,7 @@ namespace impl {
 
 template <typename pc = PhysicalConstantsCGS>
 class MeanOpacity {
+
  public:
   MeanOpacity() = default;
   template <typename Opacity>
@@ -73,7 +75,8 @@ class MeanOpacity {
           kappaPlanckDenom += opac.ThermalDistributionOfTNu(T, nu) * nu * dlnu;
 
           kappaRosselandNum +=
-              rho / opac.AbsorptionCoefficient(rho, T, nu, lambda) *
+              singularity_opac::robust::ratio(
+                  rho, opac.AbsorptionCoefficient(rho, T, nu, lambda)) *
               opac.DThermalDistributionOfTNuDT(T, nu) * nu * dlnu;
           kappaRosselandDenom +=
               opac.DThermalDistributionOfTNuDT(T, nu) * nu * dlnu;
@@ -94,9 +97,11 @@ class MeanOpacity {
                             dlnu;
         kappaRosselandNum -=
             0.5 * rho *
-            (1. / opac.AbsorptionCoefficient(rho, T, nu0, lambda) *
+            (singularity_opac::robust::ratio(
+                 1., opac.AbsorptionCoefficient(rho, T, nu0, lambda)) *
                  opac.DThermalDistributionOfTNuDT(T, nu0) * nu0 +
-             1. / opac.AbsorptionCoefficient(rho, T, nu1, lambda) *
+             singularity_opac::robust::ratio(
+                 1., opac.AbsorptionCoefficient(rho, T, nu1, lambda)) *
                  opac.DThermalDistributionOfTNuDT(T, nu1) * nu1) *
             dlnu;
         kappaRosselandDenom -=

--- a/singularity-opac/photons/mean_opacity_photons.hpp
+++ b/singularity-opac/photons/mean_opacity_photons.hpp
@@ -44,17 +44,16 @@ class MeanOpacity {
               const int NRho, const Real lTMin, const Real lTMax, const int NT,
               Real *lambda = nullptr) {
     lkappaPlanck_.resize(NRho, NT);
-    // index 0 is the species and is not interpolatable
-    lkappaPlanck_.setRange(1, lTMin, lTMax, NT);
-    lkappaPlanck_.setRange(2, lRhoMin, lRhoMax, NRho);
+    lkappaPlanck_.setRange(0, lTMin, lTMax, NT);
+    lkappaPlanck_.setRange(1, lRhoMin, lRhoMax, NRho);
     lkappaRosseland_.copyMetadata(lkappaPlanck_);
 
     // Fill tables
     for (int iRho = 0; iRho < NRho; ++iRho) {
-      Real lRho = lkappaPlanck_.range(3).x(iRho);
+      Real lRho = lkappaPlanck_.range(1).x(iRho);
       Real rho = fromLog_(lRho);
       for (int iT = 0; iT < NT; ++iT) {
-        Real lT = lkappaPlanck_.range(2).x(iT);
+        Real lT = lkappaPlanck_.range(0).x(iT);
         Real T = fromLog_(lT);
         Real kappaPlanckNum = 0.;
         Real kappaPlanckDenom = 0.;

--- a/singularity-opac/photons/mean_opacity_photons.hpp
+++ b/singularity-opac/photons/mean_opacity_photons.hpp
@@ -1,0 +1,213 @@
+// ======================================================================
+// © 2022. Triad National Security, LLC. All rights reserved.  This
+// program was produced under U.S. Government contract
+// 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
+// is operated by Triad National Security, LLC for the U.S.
+// Department of Energy/National Nuclear Security Administration. All
+// rights in the program are reserved by Triad National Security, LLC,
+// and the U.S. Department of Energy/National Nuclear Security
+// Administration. The Government is granted for itself and others
+// acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works,
+// distribute copies to the public, perform publicly and display
+// publicly, and to permit others to do so.
+// ======================================================================
+
+#ifndef SINGULARITY_OPAC_PHOTONS_MEAN_OPACITY_PHOTONS_
+#define SINGULARITY_OPAC_PHOTONS_MEAN_OPACITY_PHOTONS_
+
+#include <cmath>
+
+#include <ports-of-call/portability.hpp>
+#include <singularity-opac/base/radiation_types.hpp>
+#include <singularity-opac/base/sp5.hpp>
+#include <singularity-opac/constants/constants.hpp>
+#include <spiner/databox.hpp>
+
+#include <singularity-opac/photons/mean_photon_variant.hpp>
+
+namespace singularity {
+namespace photons {
+namespace impl {
+
+#define EPS (10.0 * std::numeric_limits<Real>::min())
+
+// TODO(BRR) Note: It is assumed that lambda is constant for all densities,
+// temperatures, and Ye
+
+template <typename pc = PhysicalConstantsCGS>
+class MeanOpacity {
+ public:
+  MeanOpacity() = default;
+  template <typename Opacity>
+  MeanOpacity(const Opacity &opac, const Real lRhoMin, const Real lRhoMax,
+              const int NRho, const Real lTMin, const Real lTMax, const int NT,
+              Real *lambda = nullptr) {
+    lkappaPlanck_.resize(NRho, NT);
+    // index 0 is the species and is not interpolatable
+    lkappaPlanck_.setRange(1, lTMin, lTMax, NT);
+    lkappaPlanck_.setRange(2, lRhoMin, lRhoMax, NRho);
+    lkappaRosseland_.copyMetadata(lkappaPlanck_);
+
+    // Fill tables
+    for (int iRho = 0; iRho < NRho; ++iRho) {
+      Real lRho = lkappaPlanck_.range(3).x(iRho);
+      Real rho = fromLog_(lRho);
+      for (int iT = 0; iT < NT; ++iT) {
+        Real lT = lkappaPlanck_.range(2).x(iT);
+        Real T = fromLog_(lT);
+            Real kappaPlanckNum = 0.;
+            Real kappaPlanckDenom = 0.;
+            Real kappaRosselandNum = 0.;
+            Real kappaRosselandDenom = 0.;
+            // Integrate over frequency
+            const int nnu = 100;
+            const Real lnuMin =
+                toLog_(1.e-3 * pc::kb * fromLog_(lTMin) / pc::h);
+            const Real lnuMax = toLog_(1.e3 * pc::kb * fromLog_(lTMax) / pc::h);
+            const Real dlnu = (lnuMax - lnuMin) / (nnu - 1);
+            for (int inu = 0; inu < nnu; ++inu) {
+              const Real lnu = lnuMin + inu * dlnu;
+              const Real nu = fromLog_(lnu);
+              kappaPlanckNum +=
+                  opac.AbsorptionCoefficient(rho, T, nu, lambda) /
+                  rho * opac.ThermalDistributionOfTNu(T, nu) * nu * dlnu;
+              kappaPlanckDenom +=
+                  opac.ThermalDistributionOfTNu(T, nu) * nu * dlnu;
+
+              kappaRosselandNum +=
+                  rho /
+                  opac.AbsorptionCoefficient(rho, T, nu, lambda) *
+                  opac.DThermalDistributionOfTNuDT(T, nu) * nu * dlnu;
+              kappaRosselandDenom +=
+                  opac.DThermalDistributionOfTNuDT(T, nu) * nu * dlnu;
+            }
+
+            // Trapezoidal rule
+            const Real nu0 = fromLog_(lnuMin);
+            const Real nu1 = fromLog_(lnuMax);
+            kappaPlanckNum -=
+                0.5 * 1. / rho *
+                (opac.AbsorptionCoefficient(rho, T, nu0, lambda) *
+                     opac.ThermalDistributionOfTNu(T, nu0) * nu0 +
+                 opac.AbsorptionCoefficient(rho, T, nu1, lambda) *
+                     opac.ThermalDistributionOfTNu(T, nu1) * nu1) *
+                dlnu;
+            kappaPlanckDenom -=
+                0.5 *
+                (opac.ThermalDistributionOfTNu(T, nu0) * nu0 +
+                 opac.ThermalDistributionOfTNu(T, nu1) * nu1) *
+                dlnu;
+            kappaRosselandNum -=
+                0.5 * rho *
+                (1. /
+                     opac.AbsorptionCoefficient(rho, T, nu0, lambda) *
+                     opac.DThermalDistributionOfTNuDT(T, nu0) * nu0 +
+                 1. /
+                     opac.AbsorptionCoefficient(rho, T, nu1, lambda) *
+                     opac.DThermalDistributionOfTNuDT(T, nu1) * nu1) *
+                dlnu;
+            kappaRosselandDenom -=
+                0.5 *
+                (opac.DThermalDistributionOfTNuDT(T, nu0) * nu0 +
+                 opac.DThermalDistributionOfTNuDT(T, nu1) * nu1) *
+                dlnu;
+
+            Real lkappaPlanck = toLog_(kappaPlanckNum / kappaPlanckDenom);
+            Real lkappaRosseland =
+                toLog_(1. / (kappaRosselandNum / kappaRosselandDenom));
+            lkappaPlanck_(iRho, iT) = lkappaPlanck;
+            lkappaRosseland_(iRho, iT) = lkappaRosseland;
+            if (std::isnan(lkappaPlanck_(iRho, iT)) ||
+                std::isnan(lkappaRosseland_(iRho, iT))) {
+              OPAC_ERROR("photons::MeanOpacity: NAN in opacity evaluations");
+            }
+          }
+        }
+      }
+    }
+  }
+
+#ifdef SPINER_USE_HDF
+  MeanOpacity(const std::string &filename) : filename_(filename.c_str()) {
+    herr_t status = H5_SUCCESS;
+    hid_t file = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
+    status += lkappaPlanck_.loadHDF(file, SP5::MeanOpac::PlanckMeanOpacity);
+    status +=
+        lkappaRosseland_.loadHDF(file, SP5::MeanOpac::RosselandMeanOpacity);
+    status += H5Fclose(file);
+
+    if (status != H5_SUCCESS) {
+      OPAC_ERROR("photons::MeanOpacity: HDF5 error\n");
+    }
+  }
+
+  void Save(const std::string &filename) const {
+    herr_t status = H5_SUCCESS;
+    hid_t file =
+        H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    status += lkappaPlanck_.saveHDF(file, SP5::MeanOpac::PlanckMeanOpacity);
+    status +=
+        lkappaRosseland_.saveHDF(file, SP5::MeanOpac::RosselandMeanOpacity);
+    status += H5Fclose(file);
+
+    if (status != H5_SUCCESS) {
+      OPAC_ERROR("photons::MeanOpacity: HDF5 error\n");
+    }
+  }
+#endif
+
+  PORTABLE_INLINE_FUNCTION void PrintParams() const {
+    printf("Mean opacity\n");
+  }
+
+  MeanOpacity GetOnDevice() {
+    MeanOpacity other;
+    other.lkappaPlanck_ = Spiner::getOnDeviceDataBox(lkappaPlanck_);
+    other.lkappaRosseland_ = Spiner::getOnDeviceDataBox(lkappaRosseland_);
+    return other;
+  }
+
+  void Finalize() {
+    lkappaPlanck_.finalize();
+    lkappaRosseland_.finalize();
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real PlanckMeanAbsorptionCoefficient(const Real rho, const Real temp) const {
+    Real lRho = toLog_(rho);
+    Real lT = toLog_(temp);
+    return rho * fromLog_(lkappaPlanck_.interpToReal(lRho, lT));
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real RosselandMeanAbsorptionCoefficient(const Real rho, const Real temp) const {
+    Real lRho = toLog_(rho);
+    Real lT = toLog_(temp);
+    return rho * fromLog_(lkappaRosseland_.interpToReal(lRho, lT));
+  }
+
+ private:
+  PORTABLE_INLINE_FUNCTION Real toLog_(const Real x) const {
+    return std::log10(std::abs(x) + EPS);
+  }
+  PORTABLE_INLINE_FUNCTION Real fromLog_(const Real lx) const {
+    return std::pow(10., lx);
+  }
+  Spiner::DataBox lkappaPlanck_;
+  Spiner::DataBox lkappaRosseland_;
+  const char *filename_;
+};
+
+#undef EPS
+
+} // namespace impl
+
+using MeanOpacityScaleFree = impl::MeanOpacity<PhysicalConstantsUnity>;
+using MeanOpacityCGS = impl::MeanOpacity<PhysicalConstantsCGS>;
+using MeanOpacity = impl::MeanVariant<MeanOpacityScaleFree, MeanOpacityCGS>;
+
+} // namespace photons
+} // namespace singularity
+
+#endif // SINGULARITY_OPAC_PHOTONS_MEAN_OPACITY_PHOTONS__

--- a/singularity-opac/photons/mean_opacity_photons.hpp
+++ b/singularity-opac/photons/mean_opacity_photons.hpp
@@ -33,8 +33,8 @@ namespace impl {
 
 #define EPS (10.0 * std::numeric_limits<Real>::min())
 
-// TODO(BRR) Note: It is assumed that lambda is constant for all densities,
-// temperatures, and Ye
+// TODO(BRR) Note: It is assumed that lambda is constant for all densities and
+// temperatures
 
 template <typename pc = PhysicalConstantsCGS>
 class MeanOpacity {

--- a/singularity-opac/photons/mean_photon_variant.hpp
+++ b/singularity-opac/photons/mean_photon_variant.hpp
@@ -71,18 +71,18 @@ class MeanVariant {
   }
 
   PORTABLE_INLINE_FUNCTION Real PlanckMeanAbsorptionCoefficient(
-      const Real rho, const Real temp, const Real Ye, const RadiationType type) const {
+      const Real rho, const Real temp) const {
     return mpark::visit(
         [=](const auto &opac) {
-          return opac.PlanckMeanAbsorptionCoefficient(rho, temp, Ye, type);
+          return opac.PlanckMeanAbsorptionCoefficient(rho, temp);
         },
         opac_);
   }
   PORTABLE_INLINE_FUNCTION Real RosselandMeanAbsorptionCoefficient(
-      const Real rho, const Real temp, const Real Ye, const RadiationType type) const {
+      const Real rho, const Real temp) const {
     return mpark::visit(
         [=](const auto &opac) {
-          return opac.RosselandMeanAbsorptionCoefficient(rho, temp, Ye, type);
+          return opac.RosselandMeanAbsorptionCoefficient(rho, temp);
         },
         opac_);
   }

--- a/singularity-opac/photons/mean_photon_variant.hpp
+++ b/singularity-opac/photons/mean_photon_variant.hpp
@@ -1,0 +1,100 @@
+// ======================================================================
+// © 2022. Triad National Security, LLC. All rights reserved.  This
+// program was produced under U.S. Government contract
+// 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
+// is operated by Triad National Security, LLC for the U.S.
+// Department of Energy/National Nuclear Security Administration. All
+// rights in the program are reserved by Triad National Security, LLC,
+// and the U.S. Department of Energy/National Nuclear Security
+// Administration. The Government is granted for itself and others
+// acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works,
+// distribute copies to the public, perform publicly and display
+// publicly, and to permit others to do so.
+// ======================================================================
+
+#ifndef SINGULARITY_OPAC_PHOTONS_MEAN_PHOTON_VARIANT_
+#define SINGULARITY_OPAC_PHOTONS_MEAN_PHOTON_VARIANT_
+
+#include <utility>
+
+#include <ports-of-call/portability.hpp>
+#include <singularity-opac/base/opac_error.hpp>
+#include <singularity-opac/base/radiation_types.hpp>
+#include <singularity-opac/photons/photon_variant.hpp>
+#include <variant/include/mpark/variant.hpp>
+
+namespace singularity {
+namespace photons {
+namespace impl {
+
+template <typename... Opacs>
+class MeanVariant {
+ private:
+  opac_variant<Opacs...> opac_;
+
+ public:
+  template <
+      typename Choice,
+      typename std::enable_if<
+          !std::is_same<MeanVariant, typename std::decay<Choice>::type>::value,
+          bool>::type = true>
+  PORTABLE_FUNCTION MeanVariant(Choice &&choice)
+      : opac_(std::forward<Choice>(choice)) {}
+
+  PORTABLE_FUNCTION
+  MeanVariant() noexcept = default;
+
+  template <
+      typename Choice,
+      typename std::enable_if<
+          !std::is_same<MeanVariant, typename std::decay<Choice>::type>::value,
+          bool>::type = true>
+  PORTABLE_FUNCTION MeanVariant &operator=(Choice &&opac) {
+    opac_ = std::forward<Choice>(opac);
+    return *this;
+  }
+
+  template <
+      typename Choice,
+      typename std::enable_if<
+          !std::is_same<MeanVariant, typename std::decay<Choice>::type>::value,
+          bool>::type = true>
+  Choice get() {
+    return mpark::get<Choice>(opac_);
+  }
+
+  MeanVariant GetOnDevice() {
+    return mpark::visit(
+        [](auto &opac) { return opac_variant<Opacs...>(opac.GetOnDevice()); },
+        opac_);
+  }
+
+  PORTABLE_INLINE_FUNCTION Real PlanckMeanAbsorptionCoefficient(
+      const Real rho, const Real temp, const Real Ye, const RadiationType type) const {
+    return mpark::visit(
+        [=](const auto &opac) {
+          return opac.PlanckMeanAbsorptionCoefficient(rho, temp, Ye, type);
+        },
+        opac_);
+  }
+  PORTABLE_INLINE_FUNCTION Real RosselandMeanAbsorptionCoefficient(
+      const Real rho, const Real temp, const Real Ye, const RadiationType type) const {
+    return mpark::visit(
+        [=](const auto &opac) {
+          return opac.RosselandMeanAbsorptionCoefficient(rho, temp, Ye, type);
+        },
+        opac_);
+  }
+
+  inline void Finalize() noexcept {
+    return mpark::visit([](auto &opac) { return opac.Finalize(); }, opac_);
+  }
+
+};
+
+} // impl
+}
+}
+
+#endif // SINGULARITY_OPAC_PHOTONS_MEAN_PHOTON_VARIANT_

--- a/singularity-opac/photons/mean_photon_variant.hpp
+++ b/singularity-opac/photons/mean_photon_variant.hpp
@@ -70,16 +70,16 @@ class MeanVariant {
         opac_);
   }
 
-  PORTABLE_INLINE_FUNCTION Real PlanckMeanAbsorptionCoefficient(
-      const Real rho, const Real temp) const {
+  PORTABLE_INLINE_FUNCTION Real
+  PlanckMeanAbsorptionCoefficient(const Real rho, const Real temp) const {
     return mpark::visit(
         [=](const auto &opac) {
           return opac.PlanckMeanAbsorptionCoefficient(rho, temp);
         },
         opac_);
   }
-  PORTABLE_INLINE_FUNCTION Real RosselandMeanAbsorptionCoefficient(
-      const Real rho, const Real temp) const {
+  PORTABLE_INLINE_FUNCTION Real
+  RosselandMeanAbsorptionCoefficient(const Real rho, const Real temp) const {
     return mpark::visit(
         [=](const auto &opac) {
           return opac.RosselandMeanAbsorptionCoefficient(rho, temp);
@@ -90,11 +90,10 @@ class MeanVariant {
   inline void Finalize() noexcept {
     return mpark::visit([](auto &opac) { return opac.Finalize(); }, opac_);
   }
-
 };
 
-} // impl
-}
-}
+} // namespace impl
+} // namespace photons
+} // namespace singularity
 
 #endif // SINGULARITY_OPAC_PHOTONS_MEAN_PHOTON_VARIANT_

--- a/singularity-opac/photons/non_cgs_photons.hpp
+++ b/singularity-opac/photons/non_cgs_photons.hpp
@@ -223,6 +223,55 @@ class NonCGSUnits {
   Real inv_intensity_unit_, inv_energy_dens_unit_;
 };
 
+template <typename MeanOpac>
+class MeanNonCGSUnits {
+ public:
+  MeanNonCGSUnits() = default;
+  MeanNonCGSUnits(MeanOpac &&mean_opac, const Real time_unit,
+                  const Real mass_unit, const Real length_unit,
+                  const Real temp_unit)
+      : mean_opac_(std::forward<MeanOpac>(mean_opac)), time_unit_(time_unit),
+        mass_unit_(mass_unit), length_unit_(length_unit), temp_unit_(temp_unit),
+        rho_unit_(mass_unit_ / (length_unit_ * length_unit_ * length_unit_)) {}
+
+  auto GetOnDevice() {
+    return MeanNonCGSUnits<MeanOpac>(mean_opac_.GetOnDevice(), time_unit_,
+                                     mass_unit_, length_unit_, temp_unit_);
+  }
+  inline void Finalize() noexcept { mean_opac_.Finalize(); }
+
+  PORTABLE_INLINE_FUNCTION
+  int nlambda() const noexcept { return mean_opac_.nlambda(); }
+
+  PORTABLE_INLINE_FUNCTION
+  Real PlanckMeanAbsorptionCoefficient(const Real rho, const Real temp) const {
+    const Real alpha = mean_opac_.PlanckMeanAbsorptionCoefficient(
+        rho_unit_ * rho, temp_unit_ * temp);
+    // alpha output in units of 1/cm. Want to convert out of CGS.
+    // multiplication by length_unit converts length to cm.
+    // division converts length from cm to unit system.
+    // thus multiplication converts (1/cm) to unit system.
+    return alpha * length_unit_;
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real RosselandMeanAbsorptionCoefficient(const Real rho,
+                                          const Real temp) const {
+    const Real alpha = mean_opac_.RosselandMeanAbsorptionCoefficient(
+        rho_unit_ * rho, temp_unit_ * temp);
+    // alpha output in units of 1/cm. Want to convert out of CGS.
+    // multiplication by length_unit converts length to cm.
+    // division converts length from cm to unit system.
+    // thus multiplication converts (1/cm) to unit system.
+    return alpha * length_unit_;
+  }
+
+ private:
+  MeanOpac mean_opac_;
+  Real time_unit_, mass_unit_, length_unit_, temp_unit_;
+  Real rho_unit_;
+};
+
 } // namespace photons
 } // namespace singularity
 

--- a/singularity-opac/photons/non_cgs_photons.hpp
+++ b/singularity-opac/photons/non_cgs_photons.hpp
@@ -152,7 +152,7 @@ class NonCGSUnits {
 
   PORTABLE_INLINE_FUNCTION
   Real Emissivity(const Real rho, const Real temp,
-                  const Real *lambda = nullptr) const {
+                  Real *lambda = nullptr) const {
     const Real J = opac_.Emissivity(rho * rho_unit_, temp * temp_unit_, lambda);
     // Jnu integrated over frequency, but divide by frequency to get out of cgs
     return J * inv_emiss_unit_ * time_unit_;

--- a/singularity-opac/photons/opac_photons.hpp
+++ b/singularity-opac/photons/opac_photons.hpp
@@ -21,11 +21,16 @@
 #include <singularity-opac/photons/photon_variant.hpp>
 #include <singularity-opac/photons/thermal_distributions_photons.hpp>
 
+#include <singularity-opac/photons/mean_opacity_photons.hpp>
+
 namespace singularity {
 namespace photons {
 
+using ScaleFree =
+    GrayOpacity<PhysicalConstantsUnity>;
 using Gray = GrayOpacity<PhysicalConstantsCGS>;
-using Opacity = impl::Variant<Gray, NonCGSUnits<Gray>>;
+
+using Opacity = impl::Variant<ScaleFree, Gray, NonCGSUnits<Gray>>;
 
 } // namespace photons
 } // namespace singularity

--- a/singularity-opac/photons/opac_photons.hpp
+++ b/singularity-opac/photons/opac_photons.hpp
@@ -26,8 +26,7 @@
 namespace singularity {
 namespace photons {
 
-using ScaleFree =
-    GrayOpacity<PhysicalConstantsUnity>;
+using ScaleFree = GrayOpacity<PhysicalConstantsUnity>;
 using Gray = GrayOpacity<PhysicalConstantsCGS>;
 
 using Opacity = impl::Variant<ScaleFree, Gray, NonCGSUnits<Gray>>;

--- a/singularity-opac/photons/thermal_distributions_photons.hpp
+++ b/singularity-opac/photons/thermal_distributions_photons.hpp
@@ -25,8 +25,6 @@
 namespace singularity {
 namespace photons {
 
-using namespace singularity - opac;
-
 template <typename pc = PhysicalConstantsCGS>
 struct PlanckDistribution {
   PORTABLE_INLINE_FUNCTION
@@ -81,7 +79,7 @@ struct PlanckDistribution {
       Real *lambda = nullptr) const {
     Real Bnu = ThermalDistributionOfTNu(temp, nu, lambda);
     Real jnu = J.EmissivityPerNuOmega(rho, temp, nu, lambda);
-    return robust::ratio(jnu, Bnu);
+    return singularity_opac::robust::ratio(jnu, Bnu);
   }
   template <typename Emissivity>
   PORTABLE_INLINE_FUNCTION Real AngleAveragedAbsorptionCoefficientFromKirkhoff(
@@ -89,7 +87,7 @@ struct PlanckDistribution {
       Real *lambda = nullptr) const {
     Real Bnu = ThermalDistributionOfTNu(temp, nu, lambda);
     Real jnu = J.EmissivityPerNu(rho, temp, nu, lambda) / (4. * M_PI);
-    return robust::ratio(jnu, Bnu);
+    return singularity_opac::robust::ratio(jnu, Bnu);
   }
 };
 

--- a/singularity-opac/photons/thermal_distributions_photons.hpp
+++ b/singularity-opac/photons/thermal_distributions_photons.hpp
@@ -19,7 +19,7 @@
 #include <cmath>
 
 #include <ports-of-call/portability.hpp>
-#include <singularity-opac/base/radiation_types.hpp>
+#include <singularity-opac/base/robust_utils.hpp>
 #include <singularity-opac/constants/constants.hpp>
 
 namespace singularity {
@@ -79,7 +79,7 @@ struct PlanckDistribution {
       Real *lambda = nullptr) const {
     Real Bnu = ThermalDistributionOfTNu(temp, nu, lambda);
     Real jnu = J.EmissivityPerNuOmega(rho, temp, nu, lambda);
-    return jnu / Bnu;
+    return robust::ratio(jnu, Bnu);
   }
   template <typename Emissivity>
   PORTABLE_INLINE_FUNCTION Real AngleAveragedAbsorptionCoefficientFromKirkhoff(
@@ -87,7 +87,7 @@ struct PlanckDistribution {
       Real *lambda = nullptr) const {
     Real Bnu = ThermalDistributionOfTNu(temp, nu, lambda);
     Real jnu = J.EmissivityPerNu(rho, temp, nu, lambda) / (4. * M_PI);
-    return jnu / Bnu;
+    return robust::ratio(jnu, Bnu);
   }
 };
 

--- a/singularity-opac/photons/thermal_distributions_photons.hpp
+++ b/singularity-opac/photons/thermal_distributions_photons.hpp
@@ -25,6 +25,8 @@
 namespace singularity {
 namespace photons {
 
+using namespace singularity - opac;
+
 template <typename pc = PhysicalConstantsCGS>
 struct PlanckDistribution {
   PORTABLE_INLINE_FUNCTION

--- a/test/test_mean_opacities.cpp
+++ b/test/test_mean_opacities.cpp
@@ -320,7 +320,7 @@ TEST_CASE("Mean photon opacities", "[MeanPhotons]") {
       constexpr Real rho_unit =
           mass_unit / (length_unit * length_unit * length_unit);
 
-      auto funny_units_host = neutrinos::MeanNonCGSUnits<photons::MeanOpacity>(
+      auto funny_units_host = photons::MeanNonCGSUnits<photons::MeanOpacity>(
           std::forward<photons::MeanOpacity>(mean_opac_host), time_unit,
           mass_unit, length_unit, temp_unit);
 

--- a/test/test_mean_opacities.cpp
+++ b/test/test_mean_opacities.cpp
@@ -281,8 +281,9 @@ TEST_CASE("Mean photon opacities", "[MeanPhotons]") {
 
         int n_wrong = 0;
         portableReduce(
-            "rebuilt table vs gray", 0, NRho, 0, NT, 0,
-            PORTABLE_LAMBDA(const int iRho, const int iT, int &accumulate) {
+            "rebuilt table vs gray", 0, NRho, 0, NT, 0, 0,
+            PORTABLE_LAMBDA(const int iRho, const int iT, const int igarbage,
+                            int &accumulate) {
               const Real lRho =
                   lRhoMin + (lRhoMax - lRhoMin) / (NRho - 1) * iRho;
               const Real rho = std::pow(10, lRho);


### PR DESCRIPTION
We already have a mean (Planck and Rosseland) opacity class for neutrinos, we want a similar feature for photons.