### PR TITLE
Thomson and Bremss opacities

### DIFF
--- a/singularity-opac/constants/constants.hpp
+++ b/singularity-opac/constants/constants.hpp
@@ -117,7 +117,7 @@ struct PhysicalConstants {
   static constexpr Real avogadro = BASE::avogadro;
   static constexpr Real na = avogadro;
 
-  static constexpr Real fine_structure = BASE::fine_structore;
+  static constexpr Real fine_structure = BASE::fine_structure;
   static constexpr Real alpha = fine_structure;
 
   static constexpr Real planck = BASE::planck * energy * time;

--- a/singularity-opac/neutrinos/mean_s_opacity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/mean_s_opacity_neutrinos.hpp
@@ -176,7 +176,7 @@ class MeanSOpacity {
 #endif
 
   PORTABLE_INLINE_FUNCTION void PrintParams() const {
-    printf("Mean opacity\n");
+    printf("Mean scattering opacity\n");
   }
 
   MeanSOpacity GetOnDevice() {

--- a/singularity-opac/photons/epbremsstrahlung_opacity_photons.hpp
+++ b/singularity-opac/photons/epbremsstrahlung_opacity_photons.hpp
@@ -27,6 +27,8 @@
 namespace singularity {
 namespace photons {
 
+// Expression for specific emissivity from Rybicki & Lightman 1979
+
 template <typename pc = PhysicalConstantsCGS>
 class EPBremsstrahlungOpacity {
  public:

--- a/singularity-opac/photons/epbremsstrahlung_opacity_photons.hpp
+++ b/singularity-opac/photons/epbremsstrahlung_opacity_photons.hpp
@@ -180,9 +180,9 @@ class EPBremsstrahlungOpacity {
       (pc::mp + pc::me) /
       (2. * pc::mp); // Neutral fully ionized electron-proton gas
   static constexpr Real gff_ = 1.2;
-  static constexpr Real prefac_ = 8. * std::pow(pc::qe, 6) /
-                                  (3. * std::pow(pc::me * pc::c * pc::c, 2)) *
-                                  std::sqrt(2. * M_PI / 3.);
+  Real prefac_ = 8. * std::pow(pc::qe, 6) /
+                 (3. * std::pow(pc::me * pc::c * pc::c, 2)) *
+                 std::sqrt(2. * M_PI / 3.);
 };
 
 } // namespace photons

--- a/singularity-opac/photons/epbremsstrahlung_opacity_photons.hpp
+++ b/singularity-opac/photons/epbremsstrahlung_opacity_photons.hpp
@@ -1,0 +1,189 @@
+// ======================================================================
+// © 2022. Triad National Security, LLC. All rights reserved.  This
+// program was produced under U.S. Government contract
+// 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
+// is operated by Triad National Security, LLC for the U.S.
+// Department of Energy/National Nuclear Security Administration. All
+// rights in the program are reserved by Triad National Security, LLC,
+// and the U.S. Department of Energy/National Nuclear Security
+// Administration. The Government is granted for itself and others
+// acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works,
+// distribute copies to the public, perform publicly and display
+// publicly, and to permit others to do so.
+// ======================================================================
+
+#ifndef SINGULARITY_OPAC_PHOTONS_EPBREMSSTRAHLUNG_OPACITY_PHOTONS_
+#define SINGULARITY_OPAC_PHOTONS_EPBREMSSTRAHLUNG_OPACITY_PHOTONS_
+
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+
+#include <ports-of-call/portability.hpp>
+#include <singularity-opac/base/opac_error.hpp>
+#include <singularity-opac/photons/thermal_distributions_photons.hpp>
+
+namespace singularity {
+namespace photons {
+
+template <typename pc = PhysicalConstantsCGS>
+class EPBremsstrahlungOpacity {
+ public:
+  EPBremsstrahlungOpacity() = default;
+  EPBremsstrahlungOpacity(const PlanckDistribution<pc> &dist) : dist_(dist) {}
+
+  EPBremsstrahlungOpacity GetOnDevice() { return *this; }
+  PORTABLE_INLINE_FUNCTION
+  int nlambda() const noexcept { return 0; }
+  PORTABLE_INLINE_FUNCTION
+  void PrintParams() const noexcept {
+    printf("Electron-proton bremsstrahlung opacity.\n");
+  }
+  inline void Finalize() noexcept {}
+
+  PORTABLE_INLINE_FUNCTION
+  Real AbsorptionCoefficient(const Real rho, const Real temp, const Real nu,
+                             Real *lambda = nullptr) const {
+    return dist_.AbsorptionCoefficientFromKirkhoff(*this, rho, temp, nu,
+                                                   lambda);
+  }
+
+  template <typename FrequencyIndexer, typename DataIndexer>
+  PORTABLE_INLINE_FUNCTION void
+  AbsorptionCoefficient(const Real rho, const Real temp,
+                        FrequencyIndexer &nu_bins, DataIndexer &coeffs,
+                        const int nbins, Real *lambda = nullptr) const {
+    for (int i = 0; i < nbins; ++i) {
+      coeffs[i] = AbsorptionCoefficient(rho, temp, nu_bins[i], lambda);
+    }
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real AngleAveragedAbsorptionCoefficient(const Real rho, const Real temp,
+                                          const Real nu,
+                                          Real *lambda = nullptr) const {
+    return dist_.AngleAveragedAbsorptionCoefficientFromKirkhoff(
+        *this, rho, temp, nu, lambda);
+  }
+
+  template <typename FrequencyIndexer, typename DataIndexer>
+  PORTABLE_INLINE_FUNCTION void AngleAveragedAbsorptionCoefficient(
+      const Real rho, const Real temp, FrequencyIndexer &nu_bins,
+      DataIndexer &coeffs, const int nbins, Real *lambda = nullptr) const {
+    for (int i = 0; i < nbins; ++i) {
+      coeffs[i] =
+          AngleAveragedAbsorptionCoefficient(rho, temp, nu_bins[i], lambda);
+    }
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real EmissivityPerNuOmega(const Real rho, const Real temp, const Real nu,
+                            Real *lambda = nullptr) const {
+    const Real thetaE = pc::kb * temp / (pc::me * pc::c * pc::c);
+    const Real x = pc::h * nu / (pc::kb * temp);
+    const Real ne = rho / mmw_;
+    const Real ni = ne;
+    return prefac_ / std::sqrt(thetaE) * ne * ni * std::exp(-x) * gff_;
+  }
+
+  template <typename FrequencyIndexer, typename DataIndexer>
+  PORTABLE_INLINE_FUNCTION void
+  EmissivityPerNuOmega(const Real rho, const Real temp,
+                       FrequencyIndexer &nu_bins, DataIndexer &coeffs,
+                       const int nbins, Real *lambda = nullptr) const {
+    for (int i = 0; i < nbins; ++i) {
+      coeffs[i] = EmissivityPerNuOmega(rho, temp, nu_bins[i], lambda);
+    }
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real EmissivityPerNu(const Real rho, const Real temp, const Real nu,
+                       Real *lambda = nullptr) const {
+    return 4 * M_PI * EmissivityPerNuOmega(rho, temp, nu, lambda);
+  }
+
+  template <typename FrequencyIndexer, typename DataIndexer>
+  PORTABLE_INLINE_FUNCTION void
+  EmissivityPerNu(const Real rho, const Real temp, FrequencyIndexer &nu_bins,
+                  DataIndexer &coeffs, const int nbins,
+                  Real *lambda = nullptr) const {
+    for (int i = 0; i < nbins; ++i) {
+      coeffs[i] = EmissivityPerNu(rho, temp, nu_bins[i], lambda);
+    }
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real Emissivity(const Real rho, const Real temp,
+                  Real *lambda = nullptr) const {
+
+    const Real thetaE = pc::kb * temp / (pc::me * pc::c * pc::c);
+    const Real ne = rho / mmw_;
+    const Real ni = ne;
+    return 4. * M_PI * pc::kb * temp / pc::h * prefac_ / std::sqrt(thetaE) *
+           ne * ni * gff_;
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real NumberEmissivity(const Real rho, const Real temp,
+                        Real *lambda = nullptr) const {
+    // Infrared catastrophe
+    return std::numeric_limits<Real>::infinity();
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real ThermalDistributionOfTNu(const Real temp, const Real nu,
+                                Real *lambda = nullptr) const {
+    return dist_.ThermalDistributionOfTNu(temp, nu, lambda);
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real DThermalDistributionOfTNuDT(const Real temp, const Real nu,
+                                   Real *lambda = nullptr) const {
+    return dist_.DThermalDistributionOfTNuDT(temp, nu, lambda);
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real ThermalDistributionOfT(const Real temp, Real *lambda = nullptr) const {
+    return dist_.ThermalDistributionOfT(temp, lambda);
+  }
+
+  PORTABLE_INLINE_FUNCTION Real
+  ThermalNumberDistributionOfT(const Real temp, Real *lambda = nullptr) const {
+    return dist_.ThermalNumberDistributionOfT(temp, lambda);
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real EnergyDensityFromTemperature(const Real temp,
+                                    Real *lambda = nullptr) const {
+    return dist_.EnergyDensityFromTemperature(temp, lambda);
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real TemperatureFromEnergyDensity(const Real er,
+                                    Real *lambda = nullptr) const {
+    return dist_.TemperatureFromEnergyDensity(er, lambda);
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real NumberDensityFromTemperature(const Real temp,
+                                    Real *lambda = nullptr) const {
+    return dist_.NumberDensityFromTemperature(temp, lambda);
+  }
+
+ private:
+  Real mass_ion_;
+  PlanckDistribution<pc> dist_;
+  static constexpr Real mmw_ =
+      (pc::mp + pc::me) /
+      (2. * pc::mp); // Neutral fully ionized electron-proton gas
+  static constexpr Real gff_ = 1.2;
+  static constexpr Real prefac_ = 8. * std::pow(pc::qe, 6) /
+                                  (3. * std::pow(pc::me * pc::c * pc::c, 2)) *
+                                  std::sqrt(2. * M_PI / 3.);
+};
+
+} // namespace photons
+} // namespace singularity
+
+#endif // SINGULARITY_OPAC_PHOTONS_EPBREMSSTRAHLUNG_OPACITY_PHOTONS_

--- a/singularity-opac/photons/gray_s_opacity_photons.hpp
+++ b/singularity-opac/photons/gray_s_opacity_photons.hpp
@@ -1,0 +1,74 @@
+// ======================================================================
+// © 2022. Triad National Security, LLC. All rights reserved.  This
+// program was produced under U.S. Government contract
+// 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
+// is operated by Triad National Security, LLC for the U.S.
+// Department of Energy/National Nuclear Security Administration. All
+// rights in the program are reserved by Triad National Security, LLC,
+// and the U.S. Department of Energy/National Nuclear Security
+// Administration. The Government is granted for itself and others
+// acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works,
+// distribute copies to the public, perform publicly and display
+// publicly, and to permit others to do so.
+// ======================================================================
+
+#ifndef SINGULARITY_OPAC_PHOTONS_GRAY_S_OPACITY_PHOTONS_
+#define SINGULARITY_OPAC_PHOTONS_GRAY_S_OPACITY_PHOTONS_
+
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+
+#include <ports-of-call/portability.hpp>
+#include <singularity-opac/base/opac_error.hpp>
+
+namespace singularity {
+namespace photons {
+
+template <typename pc = PhysicalConstantsCGS>
+class GraySOpacity {
+ public:
+  GraySOpacity() = default;
+  GraySOpacity(const Real sigma, const Real avg_particle_mass)
+      : sigma_(sigma), apm_(avg_particle_mass) {}
+
+  GraySOpacity GetOnDevice() { return *this; }
+  PORTABLE_INLINE_FUNCTION
+  int nlambda() const noexcept { return 0; }
+  PORTABLE_INLINE_FUNCTION
+  void PrintParams() const noexcept {
+    printf("Gray scattering opacity. sigma = %g avg particle mass = %g\n",
+           sigma_, apm_);
+  }
+  inline void Finalize() noexcept {}
+
+  PORTABLE_INLINE_FUNCTION
+  Real TotalCrossSection(const Real rho, const Real temp,
+                         const Real nu,
+                         Real *lambda = nullptr) const {
+    return sigma_;
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real DifferentialCrossSection(const Real rho, const Real temp,
+                                const Real nu,
+                                const Real mu, Real *lambda = nullptr) const {
+    return sigma_ / (4. * M_PI);
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real TotalScatteringCoefficient(const Real rho, const Real temp,
+                                  const Real nu, Real *lambda = nullptr) const {
+    return (rho / apm_) * sigma_;
+  }
+
+ private:
+  Real sigma_; // Scattering cross section. Units of cm^2
+  Real apm_;   // Mean molecular weight. Units of g
+};
+
+} // namespace photons
+} // namespace singularity
+
+#endif // SINGULARITY_OPAC_PHOTONS_GRAY_S_OPACITY_PHOTONS_

--- a/singularity-opac/photons/mean_opacity_photons.hpp
+++ b/singularity-opac/photons/mean_opacity_photons.hpp
@@ -110,9 +110,10 @@ class MeanOpacity {
              opac.DThermalDistributionOfTNuDT(T, nu1) * nu1) *
             dlnu;
 
-        Real lkappaPlanck = toLog_(singularity_opac::robust::ratio(kappaPlanckNum, kappaPlanckDenom));
-        Real lkappaRosseland =
-            toLog_(singularity_opac::robust::ratio(kappaRosselandDenom, kappaRosselandNum));
+        Real lkappaPlanck = toLog_(
+            singularity_opac::robust::ratio(kappaPlanckNum, kappaPlanckDenom));
+        Real lkappaRosseland = toLog_(singularity_opac::robust::ratio(
+            kappaRosselandDenom, kappaRosselandNum));
         lkappaPlanck_(iRho, iT) = lkappaPlanck;
         lkappaRosseland_(iRho, iT) = lkappaRosseland;
         if (std::isnan(lkappaPlanck_(iRho, iT)) ||

--- a/singularity-opac/photons/mean_photon_s_variant.hpp
+++ b/singularity-opac/photons/mean_photon_s_variant.hpp
@@ -1,0 +1,104 @@
+// ======================================================================
+// © 2022. Triad National Security, LLC. All rights reserved.  This
+// program was produced under U.S. Government contract
+// 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
+// is operated by Triad National Security, LLC for the U.S.
+// Department of Energy/National Nuclear Security Administration. All
+// rights in the program are reserved by Triad National Security, LLC,
+// and the U.S. Department of Energy/National Nuclear Security
+// Administration. The Government is granted for itself and others
+// acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works,
+// distribute copies to the public, perform publicly and display
+// publicly, and to permit others to do so.
+// ======================================================================
+
+#ifndef SINGULARITY_OPAC_PHOTONS_MEAN_PHOTON_S_VARIANT_
+#define SINGULARITY_OPAC_PHOTONS_MEAN_PHOTON_S_VARIANT_
+
+#include <utility>
+
+#include <ports-of-call/portability.hpp>
+#include <singularity-opac/base/opac_error.hpp>
+#include <singularity-opac/base/radiation_types.hpp>
+#include <singularity-opac/photons/photon_s_variant.hpp>
+#include <variant/include/mpark/variant.hpp>
+
+namespace singularity {
+namespace photons {
+namespace impl {
+
+template <typename... SOpacs>
+class MeanSVariant {
+ private:
+  s_opac_variant<SOpacs...> s_opac_;
+
+ public:
+  template <
+      typename Choice,
+      typename std::enable_if<
+          !std::is_same<MeanSVariant, typename std::decay<Choice>::type>::value,
+          bool>::type = true>
+  PORTABLE_FUNCTION MeanSVariant(Choice &&choice)
+      : s_opac_(std::forward<Choice>(choice)) {}
+
+  PORTABLE_FUNCTION
+  MeanSVariant() noexcept = default;
+
+  template <
+      typename Choice,
+      typename std::enable_if<
+          !std::is_same<MeanSVariant, typename std::decay<Choice>::type>::value,
+          bool>::type = true>
+  PORTABLE_FUNCTION MeanSVariant &operator=(Choice &&s_opac) {
+    s_opac_ = std::forward<Choice>(s_opac);
+    return *this;
+  }
+
+  template <
+      typename Choice,
+      typename std::enable_if<
+          !std::is_same<MeanSVariant, typename std::decay<Choice>::type>::value,
+          bool>::type = true>
+  Choice get() {
+    return mpark::get<Choice>(s_opac_);
+  }
+
+  MeanSVariant GetOnDevice() {
+    return mpark::visit(
+        [](auto &s_opac) {
+          return s_opac_variant<SOpacs...>(s_opac.GetOnDevice());
+        },
+        s_opac_);
+  }
+
+  PORTABLE_INLINE_FUNCTION Real
+  PlanckMeanTotalScatteringCoefficient(const Real rho, const Real temp) const {
+    return mpark::visit(
+        [=](const auto &s_opac) {
+          return s_opac.PlanckMeanTotalScatteringCoefficient(rho, temp
+                                                             );
+        },
+        s_opac_);
+  }
+  PORTABLE_INLINE_FUNCTION Real RosselandMeanTotalScatteringCoefficient(
+      const Real rho, const Real temp) const {
+    return mpark::visit(
+        [=](const auto &s_opac) {
+          return s_opac.RosselandMeanTotalScatteringCoefficient(rho, temp
+                                                                );
+        },
+        s_opac_);
+  }
+
+  inline void Finalize() noexcept {
+    return mpark::visit([](auto &s_opac) { return s_opac.Finalize(); },
+                        s_opac_);
+  }
+};
+
+} // namespace impl
+} // namespace photons
+} // namespace singularity
+
+#endif // SINGULARITY_OPAC_PHOTONS_MEAN_PHOTON_S_VARIANT_

--- a/singularity-opac/photons/mean_photon_s_variant.hpp
+++ b/singularity-opac/photons/mean_photon_s_variant.hpp
@@ -76,8 +76,7 @@ class MeanSVariant {
   PlanckMeanTotalScatteringCoefficient(const Real rho, const Real temp) const {
     return mpark::visit(
         [=](const auto &s_opac) {
-          return s_opac.PlanckMeanTotalScatteringCoefficient(rho, temp
-                                                             );
+          return s_opac.PlanckMeanTotalScatteringCoefficient(rho, temp);
         },
         s_opac_);
   }
@@ -85,8 +84,7 @@ class MeanSVariant {
       const Real rho, const Real temp) const {
     return mpark::visit(
         [=](const auto &s_opac) {
-          return s_opac.RosselandMeanTotalScatteringCoefficient(rho, temp
-                                                                );
+          return s_opac.RosselandMeanTotalScatteringCoefficient(rho, temp);
         },
         s_opac_);
   }

--- a/singularity-opac/photons/mean_s_opacity_photons.hpp
+++ b/singularity-opac/photons/mean_s_opacity_photons.hpp
@@ -44,8 +44,8 @@ class MeanSOpacity {
   MeanSOpacity() = default;
   template <typename SOpacity>
   MeanSOpacity(const SOpacity &s_opac, const Real lRhoMin, const Real lRhoMax,
-              const int NRho, const Real lTMin, const Real lTMax, const int NT,
-              Real *lambda = nullptr) {
+               const int NRho, const Real lTMin, const Real lTMax, const int NT,
+               Real *lambda = nullptr) {
     ThermalDistribution dist;
 
     lkappaPlanck_.resize(NRho, NT);
@@ -72,9 +72,9 @@ class MeanSOpacity {
         for (int inu = 0; inu < nnu; ++inu) {
           const Real lnu = lnuMin + inu * dlnu;
           const Real nu = fromLog_(lnu);
-          kappaPlanckNum += s_opac.TotalScatteringCoefficient(rho, T, nu, lambda) /
-                            rho * dist.ThermalDistributionOfTNu(T, nu) * nu *
-                            dlnu;
+          kappaPlanckNum +=
+              s_opac.TotalScatteringCoefficient(rho, T, nu, lambda) / rho *
+              dist.ThermalDistributionOfTNu(T, nu) * nu * dlnu;
           kappaPlanckDenom += dist.ThermalDistributionOfTNu(T, nu) * nu * dlnu;
 
           kappaRosselandNum +=
@@ -88,12 +88,13 @@ class MeanSOpacity {
         // Trapezoidal rule
         const Real nu0 = fromLog_(lnuMin);
         const Real nu1 = fromLog_(lnuMax);
-        kappaPlanckNum -= 0.5 * 1. / rho *
-                          (s_opac.TotalScatteringCoefficient(rho, T, nu0, lambda) *
-                               dist.ThermalDistributionOfTNu(T, nu0) * nu0 +
-                           s_opac.TotalScatteringCoefficient(rho, T, nu1, lambda) *
-                               dist.ThermalDistributionOfTNu(T, nu1) * nu1) *
-                          dlnu;
+        kappaPlanckNum -=
+            0.5 * 1. / rho *
+            (s_opac.TotalScatteringCoefficient(rho, T, nu0, lambda) *
+                 dist.ThermalDistributionOfTNu(T, nu0) * nu0 +
+             s_opac.TotalScatteringCoefficient(rho, T, nu1, lambda) *
+                 dist.ThermalDistributionOfTNu(T, nu1) * nu1) *
+            dlnu;
         kappaPlanckDenom -= 0.5 *
                             (dist.ThermalDistributionOfTNu(T, nu0) * nu0 +
                              dist.ThermalDistributionOfTNu(T, nu1) * nu1) *
@@ -113,9 +114,10 @@ class MeanSOpacity {
              dist.DThermalDistributionOfTNuDT(T, nu1) * nu1) *
             dlnu;
 
-        Real lkappaPlanck = toLog_(singularity_opac::robust::ratio(kappaPlanckNum, kappaPlanckDenom));
-        Real lkappaRosseland =
-            toLog_(singularity_opac::robust::ratio(kappaRosselandDenom, kappaRosselandNum));
+        Real lkappaPlanck = toLog_(
+            singularity_opac::robust::ratio(kappaPlanckNum, kappaPlanckDenom));
+        Real lkappaRosseland = toLog_(singularity_opac::robust::ratio(
+            kappaRosselandDenom, kappaRosselandNum));
         lkappaPlanck_(iRho, iT) = lkappaPlanck;
         lkappaRosseland_(iRho, iT) = lkappaRosseland;
         if (std::isnan(lkappaPlanck_(iRho, iT)) ||
@@ -172,7 +174,8 @@ class MeanSOpacity {
   }
 
   PORTABLE_INLINE_FUNCTION
-  Real PlanckMeanTotalScatteringCoefficient(const Real rho, const Real temp) const {
+  Real PlanckMeanTotalScatteringCoefficient(const Real rho,
+                                            const Real temp) const {
     Real lRho = toLog_(rho);
     Real lT = toLog_(temp);
     return rho * fromLog_(lkappaPlanck_.interpToReal(lRho, lT));
@@ -180,7 +183,7 @@ class MeanSOpacity {
 
   PORTABLE_INLINE_FUNCTION
   Real RosselandMeanTotalScatteringCoefficient(const Real rho,
-                                          const Real temp) const {
+                                               const Real temp) const {
     Real lRho = toLog_(rho);
     Real lT = toLog_(temp);
     return rho * fromLog_(lkappaRosseland_.interpToReal(lRho, lT));
@@ -202,8 +205,12 @@ class MeanSOpacity {
 
 } // namespace impl
 
-using MeanSOpacityScaleFree = impl::MeanSOpacity<PlanckDistribution<PhysicalConstantsUnity>, PhysicalConstantsUnity>;
-using MeanSOpacityCGS = impl::MeanSOpacity<PlanckDistribution<PhysicalConstantsCGS>, PhysicalConstantsCGS>;
+using MeanSOpacityScaleFree =
+    impl::MeanSOpacity<PlanckDistribution<PhysicalConstantsUnity>,
+                       PhysicalConstantsUnity>;
+using MeanSOpacityCGS =
+    impl::MeanSOpacity<PlanckDistribution<PhysicalConstantsCGS>,
+                       PhysicalConstantsCGS>;
 using MeanSOpacity = impl::MeanSVariant<MeanSOpacityScaleFree, MeanSOpacityCGS>;
 
 } // namespace photons

--- a/singularity-opac/photons/mean_s_opacity_photons.hpp
+++ b/singularity-opac/photons/mean_s_opacity_photons.hpp
@@ -13,8 +13,8 @@
 // publicly, and to permit others to do so.
 // ======================================================================
 
-#ifndef SINGULARITY_OPAC_PHOTONS_MEAN_OPACITY_PHOTONS_
-#define SINGULARITY_OPAC_PHOTONS_MEAN_OPACITY_PHOTONS_
+#ifndef SINGULARITY_OPAC_PHOTONS_MEAN_S_OPACITY_PHOTONS_
+#define SINGULARITY_OPAC_PHOTONS_MEAN_S_OPACITY_PHOTONS_
 
 #include <cmath>
 
@@ -25,7 +25,8 @@
 #include <singularity-opac/constants/constants.hpp>
 #include <spiner/databox.hpp>
 
-#include <singularity-opac/photons/mean_photon_variant.hpp>
+#include <singularity-opac/photons/mean_photon_s_variant.hpp>
+#include <singularity-opac/photons/thermal_distributions_photons.hpp>
 
 namespace singularity {
 namespace photons {
@@ -36,15 +37,17 @@ namespace impl {
 // TODO(BRR) Note: It is assumed that lambda is constant for all densities and
 // temperatures
 
-template <typename pc = PhysicalConstantsCGS>
-class MeanOpacity {
+template <typename ThermalDistribution, typename pc = PhysicalConstantsCGS>
+class MeanSOpacity {
 
  public:
-  MeanOpacity() = default;
-  template <typename Opacity>
-  MeanOpacity(const Opacity &opac, const Real lRhoMin, const Real lRhoMax,
+  MeanSOpacity() = default;
+  template <typename SOpacity>
+  MeanSOpacity(const SOpacity &s_opac, const Real lRhoMin, const Real lRhoMax,
               const int NRho, const Real lTMin, const Real lTMax, const int NT,
               Real *lambda = nullptr) {
+    ThermalDistribution dist;
+
     lkappaPlanck_.resize(NRho, NT);
     lkappaPlanck_.setRange(0, lTMin, lTMax, NT);
     lkappaPlanck_.setRange(1, lRhoMin, lRhoMax, NRho);
@@ -69,45 +72,45 @@ class MeanOpacity {
         for (int inu = 0; inu < nnu; ++inu) {
           const Real lnu = lnuMin + inu * dlnu;
           const Real nu = fromLog_(lnu);
-          kappaPlanckNum += opac.AbsorptionCoefficient(rho, T, nu, lambda) /
-                            rho * opac.ThermalDistributionOfTNu(T, nu) * nu *
+          kappaPlanckNum += s_opac.TotalScatteringCoefficient(rho, T, nu, lambda) /
+                            rho * dist.ThermalDistributionOfTNu(T, nu) * nu *
                             dlnu;
-          kappaPlanckDenom += opac.ThermalDistributionOfTNu(T, nu) * nu * dlnu;
+          kappaPlanckDenom += dist.ThermalDistributionOfTNu(T, nu) * nu * dlnu;
 
           kappaRosselandNum +=
               singularity_opac::robust::ratio(
-                  rho, opac.AbsorptionCoefficient(rho, T, nu, lambda)) *
-              opac.DThermalDistributionOfTNuDT(T, nu) * nu * dlnu;
+                  rho, s_opac.TotalScatteringCoefficient(rho, T, nu, lambda)) *
+              dist.DThermalDistributionOfTNuDT(T, nu) * nu * dlnu;
           kappaRosselandDenom +=
-              opac.DThermalDistributionOfTNuDT(T, nu) * nu * dlnu;
+              dist.DThermalDistributionOfTNuDT(T, nu) * nu * dlnu;
         }
 
         // Trapezoidal rule
         const Real nu0 = fromLog_(lnuMin);
         const Real nu1 = fromLog_(lnuMax);
         kappaPlanckNum -= 0.5 * 1. / rho *
-                          (opac.AbsorptionCoefficient(rho, T, nu0, lambda) *
-                               opac.ThermalDistributionOfTNu(T, nu0) * nu0 +
-                           opac.AbsorptionCoefficient(rho, T, nu1, lambda) *
-                               opac.ThermalDistributionOfTNu(T, nu1) * nu1) *
+                          (s_opac.TotalScatteringCoefficient(rho, T, nu0, lambda) *
+                               dist.ThermalDistributionOfTNu(T, nu0) * nu0 +
+                           s_opac.TotalScatteringCoefficient(rho, T, nu1, lambda) *
+                               dist.ThermalDistributionOfTNu(T, nu1) * nu1) *
                           dlnu;
         kappaPlanckDenom -= 0.5 *
-                            (opac.ThermalDistributionOfTNu(T, nu0) * nu0 +
-                             opac.ThermalDistributionOfTNu(T, nu1) * nu1) *
+                            (dist.ThermalDistributionOfTNu(T, nu0) * nu0 +
+                             dist.ThermalDistributionOfTNu(T, nu1) * nu1) *
                             dlnu;
         kappaRosselandNum -=
             0.5 * rho *
             (singularity_opac::robust::ratio(
-                 1., opac.AbsorptionCoefficient(rho, T, nu0, lambda)) *
-                 opac.DThermalDistributionOfTNuDT(T, nu0) * nu0 +
+                 1., s_opac.TotalScatteringCoefficient(rho, T, nu0, lambda)) *
+                 dist.DThermalDistributionOfTNuDT(T, nu0) * nu0 +
              singularity_opac::robust::ratio(
-                 1., opac.AbsorptionCoefficient(rho, T, nu1, lambda)) *
-                 opac.DThermalDistributionOfTNuDT(T, nu1) * nu1) *
+                 1., s_opac.TotalScatteringCoefficient(rho, T, nu1, lambda)) *
+                 dist.DThermalDistributionOfTNuDT(T, nu1) * nu1) *
             dlnu;
         kappaRosselandDenom -=
             0.5 *
-            (opac.DThermalDistributionOfTNuDT(T, nu0) * nu0 +
-             opac.DThermalDistributionOfTNuDT(T, nu1) * nu1) *
+            (dist.DThermalDistributionOfTNuDT(T, nu0) * nu0 +
+             dist.DThermalDistributionOfTNuDT(T, nu1) * nu1) *
             dlnu;
 
         Real lkappaPlanck = toLog_(singularity_opac::robust::ratio(kappaPlanckNum, kappaPlanckDenom));
@@ -117,23 +120,23 @@ class MeanOpacity {
         lkappaRosseland_(iRho, iT) = lkappaRosseland;
         if (std::isnan(lkappaPlanck_(iRho, iT)) ||
             std::isnan(lkappaRosseland_(iRho, iT))) {
-          OPAC_ERROR("photons::MeanOpacity: NAN in opacity evaluations");
+          OPAC_ERROR("photons::MeanSOpacity: NAN in opacity evaluations");
         }
       }
     }
   }
 
 #ifdef SPINER_USE_HDF
-  MeanOpacity(const std::string &filename) : filename_(filename.c_str()) {
+  MeanSOpacity(const std::string &filename) : filename_(filename.c_str()) {
     herr_t status = H5_SUCCESS;
     hid_t file = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
-    status += lkappaPlanck_.loadHDF(file, SP5::MeanOpac::PlanckMeanOpacity);
+    status += lkappaPlanck_.loadHDF(file, SP5::MeanSOpac::PlanckMeanSOpacity);
     status +=
-        lkappaRosseland_.loadHDF(file, SP5::MeanOpac::RosselandMeanOpacity);
+        lkappaRosseland_.loadHDF(file, SP5::MeanSOpac::RosselandMeanSOpacity);
     status += H5Fclose(file);
 
     if (status != H5_SUCCESS) {
-      OPAC_ERROR("photons::MeanOpacity: HDF5 error\n");
+      OPAC_ERROR("photons::MeanSOpacity: HDF5 error\n");
     }
   }
 
@@ -141,23 +144,23 @@ class MeanOpacity {
     herr_t status = H5_SUCCESS;
     hid_t file =
         H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
-    status += lkappaPlanck_.saveHDF(file, SP5::MeanOpac::PlanckMeanOpacity);
+    status += lkappaPlanck_.saveHDF(file, SP5::MeanSOpac::PlanckMeanSOpacity);
     status +=
-        lkappaRosseland_.saveHDF(file, SP5::MeanOpac::RosselandMeanOpacity);
+        lkappaRosseland_.saveHDF(file, SP5::MeanSOpac::RosselandMeanSOpacity);
     status += H5Fclose(file);
 
     if (status != H5_SUCCESS) {
-      OPAC_ERROR("photons::MeanOpacity: HDF5 error\n");
+      OPAC_ERROR("photons::MeanSOpacity: HDF5 error\n");
     }
   }
 #endif
 
   PORTABLE_INLINE_FUNCTION void PrintParams() const {
-    printf("Mean opacity\n");
+    printf("Mean scattering opacity\n");
   }
 
-  MeanOpacity GetOnDevice() {
-    MeanOpacity other;
+  MeanSOpacity GetOnDevice() {
+    MeanSOpacity other;
     other.lkappaPlanck_ = Spiner::getOnDeviceDataBox(lkappaPlanck_);
     other.lkappaRosseland_ = Spiner::getOnDeviceDataBox(lkappaRosseland_);
     return other;
@@ -169,14 +172,14 @@ class MeanOpacity {
   }
 
   PORTABLE_INLINE_FUNCTION
-  Real PlanckMeanAbsorptionCoefficient(const Real rho, const Real temp) const {
+  Real PlanckMeanTotalScatteringCoefficient(const Real rho, const Real temp) const {
     Real lRho = toLog_(rho);
     Real lT = toLog_(temp);
     return rho * fromLog_(lkappaPlanck_.interpToReal(lRho, lT));
   }
 
   PORTABLE_INLINE_FUNCTION
-  Real RosselandMeanAbsorptionCoefficient(const Real rho,
+  Real RosselandMeanTotalScatteringCoefficient(const Real rho,
                                           const Real temp) const {
     Real lRho = toLog_(rho);
     Real lT = toLog_(temp);
@@ -199,11 +202,11 @@ class MeanOpacity {
 
 } // namespace impl
 
-using MeanOpacityScaleFree = impl::MeanOpacity<PhysicalConstantsUnity>;
-using MeanOpacityCGS = impl::MeanOpacity<PhysicalConstantsCGS>;
-using MeanOpacity = impl::MeanVariant<MeanOpacityScaleFree, MeanOpacityCGS>;
+using MeanSOpacityScaleFree = impl::MeanSOpacity<PlanckDistribution<PhysicalConstantsUnity>, PhysicalConstantsUnity>;
+using MeanSOpacityCGS = impl::MeanSOpacity<PlanckDistribution<PhysicalConstantsCGS>, PhysicalConstantsCGS>;
+using MeanSOpacity = impl::MeanSVariant<MeanSOpacityScaleFree, MeanSOpacityCGS>;
 
 } // namespace photons
 } // namespace singularity
 
-#endif // SINGULARITY_OPAC_PHOTONS_MEAN_OPACITY_PHOTONS__
+#endif // SINGULARITY_OPAC_PHOTONS_MEAN_S_OPACITY_PHOTONS__

--- a/singularity-opac/photons/non_cgs_s_photons.hpp
+++ b/singularity-opac/photons/non_cgs_s_photons.hpp
@@ -1,0 +1,140 @@
+// ======================================================================
+// © 2022. Triad National Security, LLC. All rights reserved.  This
+// program was produced under U.S. Government contract
+// 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
+// is operated by Triad National Security, LLC for the U.S.
+// Department of Energy/National Nuclear Security Administration. All
+// rights in the program are reserved by Triad National Security, LLC,
+// and the U.S. Department of Energy/National Nuclear Security
+// Administration. The Government is granted for itself and others
+// acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works,
+// distribute copies to the public, perform publicly and display
+// publicly, and to permit others to do so.
+// ======================================================================
+
+#ifndef SINGULARITY_OPAC_PHOTONS_NON_CGS_S_PHOTONS_
+#define SINGULARITY_OPAC_PHOTONS_NON_CGS_S_PHOTONS_
+
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+
+#include <ports-of-call/portability.hpp>
+#include <singularity-opac/base/opac_error.hpp>
+
+namespace singularity {
+namespace photons {
+
+template <typename SOpac>
+class NonCGSUnitsS {
+ public:
+  NonCGSUnitsS() = default;
+  NonCGSUnitsS(SOpac &&s_opac, const Real time_unit, const Real mass_unit,
+               const Real length_unit, const Real temp_unit)
+      : s_opac_(std::forward<SOpac>(s_opac)), time_unit_(time_unit),
+        mass_unit_(mass_unit), length_unit_(length_unit), temp_unit_(temp_unit),
+        rho_unit_(mass_unit_ / (length_unit_ * length_unit_ * length_unit_)),
+        freq_unit_(1. / time_unit_) {}
+
+  auto GetOnDevice() {
+    return NonCGSUnitsS<SOpac>(s_opac_.GetOnDevice(), time_unit_, mass_unit_,
+                               length_unit_, temp_unit_);
+  }
+  inline void Finalize() noexcept { s_opac_.Finalize(); }
+
+  PORTABLE_INLINE_FUNCTION
+  int nlambda() const noexcept { return s_opac_.nlambda(); }
+
+  PORTABLE_INLINE_FUNCTION
+  Real TotalCrossSection(const Real rho, const Real temp,
+                         const Real nu,
+                         Real *lambda = nullptr) const {
+    const Real sigma = s_opac_.TotalCrossSection(
+        rho_unit_ * rho, temp_unit_ * temp, nu * freq_unit_, lambda);
+    return sigma / (length_unit_ * length_unit_);
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real DifferentialCrossSection(const Real rho, const Real temp,
+                                const Real nu,
+                                const Real mu, Real *lambda = nullptr) const {
+    const Real dsigma =
+        s_opac_.DifferentialCrossSection(rho_unit_ * rho, temp_unit_ * temp,
+                                         nu * freq_unit_, mu, lambda);
+    return dsigma / (length_unit_ * length_unit_);
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real TotalScatteringCoefficient(const Real rho, const Real temp,
+                                  const Real nu, Real *lambda = nullptr) const {
+    const Real alpha = s_opac_.TotalScatteringCoefficient(
+        rho_unit_ * rho, temp_unit_ * temp, nu * freq_unit_, lambda);
+    // alpha output in units of 1/cm. Want to convert out of CGS.
+    // multiplication by length_unit converts length to cm.
+    // division converts length from cm to unit system.
+    // thus multiplication converts (1/cm) to unit system.
+    return alpha * length_unit_;
+  }
+
+ private:
+  SOpac s_opac_;
+  Real time_unit_, mass_unit_, length_unit_, temp_unit_;
+  Real rho_unit_, freq_unit_;
+};
+
+template <typename MeanSOpac>
+class MeanNonCGSUnitsS {
+ public:
+  MeanNonCGSUnitsS() = default;
+  MeanNonCGSUnitsS(MeanSOpac &&mean_s_opac, const Real time_unit,
+                   const Real mass_unit, const Real length_unit,
+                   const Real temp_unit)
+      : mean_s_opac_(std::forward<MeanSOpac>(mean_s_opac)),
+        time_unit_(time_unit), mass_unit_(mass_unit), length_unit_(length_unit),
+        temp_unit_(temp_unit),
+        rho_unit_(mass_unit_ / (length_unit_ * length_unit_ * length_unit_)) {}
+
+  auto GetOnDevice() {
+    return MeanNonCGSUnitsS<MeanSOpac>(mean_s_opac_.GetOnDevice(), time_unit_,
+                                       mass_unit_, length_unit_, temp_unit_);
+  }
+  inline void Finalize() noexcept { mean_s_opac_.Finalize(); }
+
+  PORTABLE_INLINE_FUNCTION
+  int nlambda() const noexcept { return mean_s_opac_.nlambda(); }
+
+  PORTABLE_INLINE_FUNCTION
+  Real PlanckMeanTotalScatteringCoefficient(const Real rho, const Real temp
+                                            ) const {
+    const Real alpha = mean_s_opac_.PlanckMeanTotalScatteringCoefficient(
+        rho_unit_ * rho, temp_unit_ * temp);
+    // alpha output in units of 1/cm. Want to convert out of CGS.
+    // multiplication by length_unit converts length to cm.
+    // division converts length from cm to unit system.
+    // thus multiplication converts (1/cm) to unit system.
+    return alpha * length_unit_;
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  Real RosselandMeanTotalScatteringCoefficient(const Real rho, const Real temp
+                                               ) const {
+    const Real alpha = mean_s_opac_.RosselandMeanTotalScatteringCoefficient(
+        rho_unit_ * rho, temp_unit_ * temp);
+    // alpha output in units of 1/cm. Want to convert out of CGS.
+    // multiplication by length_unit converts length to cm.
+    // division converts length from cm to unit system.
+    // thus multiplication converts (1/cm) to unit system.
+    return alpha * length_unit_;
+  }
+
+ private:
+  MeanSOpac mean_s_opac_;
+  Real time_unit_, mass_unit_, length_unit_, temp_unit_;
+  Real rho_unit_;
+};
+
+} // namespace photons
+} // namespace singularity
+
+#endif // SINGULARITY_OPAC_PHOTONS_NON_CGS_S_PHOTONS_

--- a/singularity-opac/photons/non_cgs_s_photons.hpp
+++ b/singularity-opac/photons/non_cgs_s_photons.hpp
@@ -47,8 +47,7 @@ class NonCGSUnitsS {
   int nlambda() const noexcept { return s_opac_.nlambda(); }
 
   PORTABLE_INLINE_FUNCTION
-  Real TotalCrossSection(const Real rho, const Real temp,
-                         const Real nu,
+  Real TotalCrossSection(const Real rho, const Real temp, const Real nu,
                          Real *lambda = nullptr) const {
     const Real sigma = s_opac_.TotalCrossSection(
         rho_unit_ * rho, temp_unit_ * temp, nu * freq_unit_, lambda);
@@ -56,12 +55,10 @@ class NonCGSUnitsS {
   }
 
   PORTABLE_INLINE_FUNCTION
-  Real DifferentialCrossSection(const Real rho, const Real temp,
-                                const Real nu,
+  Real DifferentialCrossSection(const Real rho, const Real temp, const Real nu,
                                 const Real mu, Real *lambda = nullptr) const {
-    const Real dsigma =
-        s_opac_.DifferentialCrossSection(rho_unit_ * rho, temp_unit_ * temp,
-                                         nu * freq_unit_, mu, lambda);
+    const Real dsigma = s_opac_.DifferentialCrossSection(
+        rho_unit_ * rho, temp_unit_ * temp, nu * freq_unit_, mu, lambda);
     return dsigma / (length_unit_ * length_unit_);
   }
 
@@ -105,8 +102,8 @@ class MeanNonCGSUnitsS {
   int nlambda() const noexcept { return mean_s_opac_.nlambda(); }
 
   PORTABLE_INLINE_FUNCTION
-  Real PlanckMeanTotalScatteringCoefficient(const Real rho, const Real temp
-                                            ) const {
+  Real PlanckMeanTotalScatteringCoefficient(const Real rho,
+                                            const Real temp) const {
     const Real alpha = mean_s_opac_.PlanckMeanTotalScatteringCoefficient(
         rho_unit_ * rho, temp_unit_ * temp);
     // alpha output in units of 1/cm. Want to convert out of CGS.
@@ -117,8 +114,8 @@ class MeanNonCGSUnitsS {
   }
 
   PORTABLE_INLINE_FUNCTION
-  Real RosselandMeanTotalScatteringCoefficient(const Real rho, const Real temp
-                                               ) const {
+  Real RosselandMeanTotalScatteringCoefficient(const Real rho,
+                                               const Real temp) const {
     const Real alpha = mean_s_opac_.RosselandMeanTotalScatteringCoefficient(
         rho_unit_ * rho, temp_unit_ * temp);
     // alpha output in units of 1/cm. Want to convert out of CGS.

--- a/singularity-opac/photons/opac_photons.hpp
+++ b/singularity-opac/photons/opac_photons.hpp
@@ -16,6 +16,7 @@
 #ifndef SINGULARITY_OPAC_PHOTONS_OPAC_PHOTONS_
 #define SINGULARITY_OPAC_PHOTONS_OPAC_PHOTONS_
 
+#include <singularity-opac/photons/epbremsstrahlung_opacity_photons.hpp>
 #include <singularity-opac/photons/gray_opacity_photons.hpp>
 #include <singularity-opac/photons/non_cgs_photons.hpp>
 #include <singularity-opac/photons/photon_variant.hpp>
@@ -28,8 +29,10 @@ namespace photons {
 
 using ScaleFree = GrayOpacity<PhysicalConstantsUnity>;
 using Gray = GrayOpacity<PhysicalConstantsCGS>;
+using EPBremss = EPBremsstrahlungOpacity<PhysicalConstantsCGS>;
 
-using Opacity = impl::Variant<ScaleFree, Gray, NonCGSUnits<Gray>>;
+using Opacity = impl::Variant<ScaleFree, Gray, EPBremss, NonCGSUnits<Gray>,
+                              NonCGSUnits<EPBremss>>;
 
 } // namespace photons
 } // namespace singularity

--- a/singularity-opac/photons/photon_s_variant.hpp
+++ b/singularity-opac/photons/photon_s_variant.hpp
@@ -1,0 +1,145 @@
+// ======================================================================
+// © 2021. Triad National Security, LLC. All rights reserved.  This
+// program was produced under U.S. Government contract
+// 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
+// is operated by Triad National Security, LLC for the U.S.
+// Department of Energy/National Nuclear Security Administration. All
+// rights in the program are reserved by Triad National Security, LLC,
+// and the U.S. Department of Energy/National Nuclear Security
+// Administration. The Government is granted for itself and others
+// acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works,
+// distribute copies to the public, perform publicly and display
+// publicly, and to permit others to do so.
+// ======================================================================
+
+#ifndef SINGULARITY_OPAC_PHOTONS_PHOTON_S_VARIANT_
+#define SINGULARITY_OPAC_PHOTONS_PHOTON_S_VARIANT_
+
+#include <utility>
+
+#include <ports-of-call/portability.hpp>
+#include <singularity-opac/base/opac_error.hpp>
+#include <singularity-opac/base/radiation_types.hpp>
+#include <variant/include/mpark/variant.hpp>
+
+namespace singularity {
+namespace photons {
+namespace impl {
+
+template <typename... Ts>
+using s_opac_variant = mpark::variant<Ts...>;
+
+template <typename... S_Opacs>
+class S_Variant {
+ private:
+  s_opac_variant<S_Opacs...> s_opac_;
+
+ public:
+  template <
+      typename Choice,
+      typename std::enable_if<
+          !std::is_same<S_Variant, typename std::decay<Choice>::type>::value,
+          bool>::type = true>
+  PORTABLE_FUNCTION S_Variant(Choice &&choice)
+      : s_opac_(std::forward<Choice>(choice)) {}
+
+  PORTABLE_FUNCTION
+  S_Variant() noexcept = default;
+
+  template <
+      typename Choice,
+      typename std::enable_if<
+          !std::is_same<S_Variant, typename std::decay<Choice>::type>::value,
+          bool>::type = true>
+  PORTABLE_FUNCTION S_Variant &operator=(Choice &&s_opac) {
+    s_opac_ = std::forward<Choice>(s_opac);
+    return *this;
+  }
+
+  template <
+      typename Choice,
+      typename std::enable_if<
+          !std::is_same<S_Variant, typename std::decay<Choice>::type>::value,
+          bool>::type = true>
+  Choice get() {
+    return mpark::get<Choice>(s_opac_);
+  }
+
+  S_Variant GetOnDevice() {
+    return mpark::visit(
+        [](auto &s_opac) {
+          return s_opac_variant<S_Opacs...>(s_opac.GetOnDevice());
+        },
+        s_opac_);
+  }
+
+  // Total cross section with units of length^2
+  // Signature should be at least
+  // rho, temp, Ye, type, nu, lambda
+  PORTABLE_INLINE_FUNCTION Real TotalCrossSection(
+      const Real rho, const Real temp,
+      const Real nu, Real *lambda = nullptr) const {
+    return mpark::visit(
+        [=](const auto &s_opac) {
+          return s_opac.TotalCrossSection(rho, temp, nu, lambda);
+        },
+        s_opac_);
+  }
+
+  // Differential cross section with units of length^2/steradian
+  // Signature should be at least
+  // rho, temp, Ye, type, nu, mu, lambda
+  PORTABLE_INLINE_FUNCTION Real DifferentialCrossSection(
+      const Real rho, const Real temp,
+      const Real nu, const Real mu, Real *lambda = nullptr) const {
+    return mpark::visit(
+        [=](const auto &s_opac) {
+          return s_opac.DifferentialCrossSection(rho, temp, nu, mu,
+                                                 lambda);
+        },
+        s_opac_);
+  }
+
+  // Total scattering coefficient with units of 1/length
+  // Signature should be at least
+  // rho, temp, Ye, type, nu, lambda
+  PORTABLE_INLINE_FUNCTION Real TotalScatteringCoefficient(
+      const Real rho, const Real temp,
+      const Real nu, Real *lambda = nullptr) const {
+    return mpark::visit(
+        [=](const auto &s_opac) {
+          return s_opac.TotalScatteringCoefficient(rho, temp, nu,
+                                                   lambda);
+        },
+        s_opac_);
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  int nlambda() const noexcept {
+    return mpark::visit([](const auto &s_opac) { return s_opac.nlambda(); },
+                        s_opac_);
+  }
+
+  template <typename T>
+  PORTABLE_INLINE_FUNCTION bool IsType() const noexcept {
+    return mpark::holds_alternative<T>(s_opac_);
+  }
+
+  PORTABLE_INLINE_FUNCTION
+  void PrintParams() const noexcept {
+    return mpark::visit([](const auto &s_opac) { return s_opac.PrintParams(); },
+                        s_opac_);
+  }
+
+  inline void Finalize() noexcept {
+    return mpark::visit([](auto &s_opac) { return s_opac.Finalize(); },
+                        s_opac_);
+  }
+};
+
+} // namespace impl
+} // namespace photons
+} // namespace singularity
+
+#endif // SINGUALRITY_OPAC_PHOTONS_PHOTON_S_VARIANT_

--- a/singularity-opac/photons/photon_s_variant.hpp
+++ b/singularity-opac/photons/photon_s_variant.hpp
@@ -77,9 +77,9 @@ class S_Variant {
   // Total cross section with units of length^2
   // Signature should be at least
   // rho, temp, Ye, type, nu, lambda
-  PORTABLE_INLINE_FUNCTION Real TotalCrossSection(
-      const Real rho, const Real temp,
-      const Real nu, Real *lambda = nullptr) const {
+  PORTABLE_INLINE_FUNCTION Real
+  TotalCrossSection(const Real rho, const Real temp, const Real nu,
+                    Real *lambda = nullptr) const {
     return mpark::visit(
         [=](const auto &s_opac) {
           return s_opac.TotalCrossSection(rho, temp, nu, lambda);
@@ -90,13 +90,12 @@ class S_Variant {
   // Differential cross section with units of length^2/steradian
   // Signature should be at least
   // rho, temp, Ye, type, nu, mu, lambda
-  PORTABLE_INLINE_FUNCTION Real DifferentialCrossSection(
-      const Real rho, const Real temp,
-      const Real nu, const Real mu, Real *lambda = nullptr) const {
+  PORTABLE_INLINE_FUNCTION Real
+  DifferentialCrossSection(const Real rho, const Real temp, const Real nu,
+                           const Real mu, Real *lambda = nullptr) const {
     return mpark::visit(
         [=](const auto &s_opac) {
-          return s_opac.DifferentialCrossSection(rho, temp, nu, mu,
-                                                 lambda);
+          return s_opac.DifferentialCrossSection(rho, temp, nu, mu, lambda);
         },
         s_opac_);
   }
@@ -104,13 +103,12 @@ class S_Variant {
   // Total scattering coefficient with units of 1/length
   // Signature should be at least
   // rho, temp, Ye, type, nu, lambda
-  PORTABLE_INLINE_FUNCTION Real TotalScatteringCoefficient(
-      const Real rho, const Real temp,
-      const Real nu, Real *lambda = nullptr) const {
+  PORTABLE_INLINE_FUNCTION Real
+  TotalScatteringCoefficient(const Real rho, const Real temp, const Real nu,
+                             Real *lambda = nullptr) const {
     return mpark::visit(
         [=](const auto &s_opac) {
-          return s_opac.TotalScatteringCoefficient(rho, temp, nu,
-                                                   lambda);
+          return s_opac.TotalScatteringCoefficient(rho, temp, nu, lambda);
         },
         s_opac_);
   }

--- a/singularity-opac/photons/s_opac_photons.hpp
+++ b/singularity-opac/photons/s_opac_photons.hpp
@@ -1,0 +1,37 @@
+// ======================================================================
+// © 2022. Triad National Security, LLC. All rights reserved.  This
+// program was produced under U.S. Government contract
+// 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
+// is operated by Triad National Security, LLC for the U.S.
+// Department of Energy/National Nuclear Security Administration. All
+// rights in the program are reserved by Triad National Security, LLC,
+// and the U.S. Department of Energy/National Nuclear Security
+// Administration. The Government is granted for itself and others
+// acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works,
+// distribute copies to the public, perform publicly and display
+// publicly, and to permit others to do so.
+// ======================================================================
+
+#ifndef SINGULARITY_OPAC_PHOTONS_S_OPAC_PHOTONS_
+#define SINGULARITY_OPAC_PHOTONS_S_OPAC_PHOTONS_
+
+#include <variant/include/mpark/variant.hpp>
+
+#include <singularity-opac/photons/gray_s_opacity_photons.hpp>
+#include <singularity-opac/photons/photon_s_variant.hpp>
+#include <singularity-opac/photons/non_cgs_s_photons.hpp>
+
+namespace singularity {
+namespace photons {
+
+// TODO(JMM): Include chemical potential
+using ScaleFreeS = GraySOpacity<PhysicalConstantsUnity>;
+using GrayS = GraySOpacity<>;
+
+using SOpacity = impl::S_Variant<ScaleFreeS, GrayS, NonCGSUnitsS<GrayS>>;
+
+} // namespace photons
+} // namespace singularity
+
+#endif // SINGULARITY_OPAC_PHOTONS_S_OPAC_PHOTONS_

--- a/singularity-opac/photons/s_opac_photons.hpp
+++ b/singularity-opac/photons/s_opac_photons.hpp
@@ -19,8 +19,9 @@
 #include <variant/include/mpark/variant.hpp>
 
 #include <singularity-opac/photons/gray_s_opacity_photons.hpp>
-#include <singularity-opac/photons/photon_s_variant.hpp>
 #include <singularity-opac/photons/non_cgs_s_photons.hpp>
+#include <singularity-opac/photons/photon_s_variant.hpp>
+#include <singularity-opac/photons/thomson_s_opacity_photons.hpp>
 
 namespace singularity {
 namespace photons {
@@ -28,8 +29,10 @@ namespace photons {
 // TODO(JMM): Include chemical potential
 using ScaleFreeS = GraySOpacity<PhysicalConstantsUnity>;
 using GrayS = GraySOpacity<>;
+using ThomsonS = ThomsonSOpacity<>;
 
-using SOpacity = impl::S_Variant<ScaleFreeS, GrayS, NonCGSUnitsS<GrayS>>;
+using SOpacity = impl::S_Variant<ScaleFreeS, GrayS, ThomsonS,
+                                 NonCGSUnitsS<GrayS>, NonCGSUnitsS<ThomsonS>>;
 
 } // namespace photons
 } // namespace singularity

--- a/singularity-opac/photons/s_opac_photons.hpp
+++ b/singularity-opac/photons/s_opac_photons.hpp
@@ -26,7 +26,6 @@
 namespace singularity {
 namespace photons {
 
-// TODO(JMM): Include chemical potential
 using ScaleFreeS = GraySOpacity<PhysicalConstantsUnity>;
 using GrayS = GraySOpacity<>;
 using ThomsonS = ThomsonSOpacity<>;

--- a/singularity-opac/photons/thomson_s_opacity_photons.hpp
+++ b/singularity-opac/photons/thomson_s_opacity_photons.hpp
@@ -13,8 +13,8 @@
 // publicly, and to permit others to do so.
 // ======================================================================
 
-#ifndef SINGULARITY_OPAC_PHOTONS_GRAY_S_OPACITY_PHOTONS_
-#define SINGULARITY_OPAC_PHOTONS_GRAY_S_OPACITY_PHOTONS_
+#ifndef SINGULARITY_OPAC_PHOTONS_THOMSON_S_OPACITY_PHOTONS_
+#define SINGULARITY_OPAC_PHOTONS_THOMSON_S_OPACITY_PHOTONS_
 
 #include <cassert>
 #include <cmath>
@@ -27,46 +27,47 @@ namespace singularity {
 namespace photons {
 
 template <typename pc = PhysicalConstantsCGS>
-class GraySOpacity {
+class ThomsonSOpacity {
  public:
-  GraySOpacity() = default;
-  GraySOpacity(const Real sigma, const Real avg_particle_mass)
-      : sigma_(sigma), apm_(avg_particle_mass) {}
+  ThomsonSOpacity() = default;
+  ThomsonSOpacity(const Real avg_particle_mass)
+      : sigmaT_(8. * M_PI / 3. *
+                std::pow(pc::alpha * pc::hbar / (pc::me * pc::c), 2)),
+        apm_(avg_particle_mass) {}
 
-  GraySOpacity GetOnDevice() { return *this; }
+  ThomsonSOpacity GetOnDevice() { return *this; }
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept { return 0; }
   PORTABLE_INLINE_FUNCTION
   void PrintParams() const noexcept {
-    printf("Gray scattering opacity. sigma = %g avg particle mass = %g\n",
-           sigma_, apm_);
+    printf("Thomson scattering opacity. avg particle mass = %g\n", apm_);
   }
   inline void Finalize() noexcept {}
 
   PORTABLE_INLINE_FUNCTION
   Real TotalCrossSection(const Real rho, const Real temp, const Real nu,
                          Real *lambda = nullptr) const {
-    return sigma_;
+    return sigmaT_;
   }
 
   PORTABLE_INLINE_FUNCTION
   Real DifferentialCrossSection(const Real rho, const Real temp, const Real nu,
                                 const Real mu, Real *lambda = nullptr) const {
-    return sigma_ / (4. * M_PI);
+    return sigmaT_ / (4. * M_PI);
   }
 
   PORTABLE_INLINE_FUNCTION
   Real TotalScatteringCoefficient(const Real rho, const Real temp,
                                   const Real nu, Real *lambda = nullptr) const {
-    return (rho / apm_) * sigma_;
+    return (rho / apm_) * sigmaT_;
   }
 
  private:
-  Real sigma_; // Scattering cross section. Units of cm^2
-  Real apm_;   // Mean molecular weight. Units of g
+  Real sigmaT_; // Scattering cross section. Units of cm^2
+  Real apm_;    // Mean molecular weight. Units of g
 };
 
 } // namespace photons
 } // namespace singularity
 
-#endif // SINGULARITY_OPAC_PHOTONS_GRAY_S_OPACITY_PHOTONS_
+#endif // SINGULARITY_OPAC_PHOTONS_THOMSON_S_OPACITY_PHOTONS_

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,6 +39,7 @@ PRIVATE
   test_gray_opacities.cpp
   test_gray_s_opacities.cpp
   test_brt_opacities.cpp
+  test_thomson_s_opacities.cpp
   test_chebyshev.cpp
   test_spiner_opac_neutrinos.cpp
   test_mean_opacities.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,6 +37,7 @@ PRIVATE
   test_thermal_dist.cpp
   test_scalefree_opacities.cpp
   test_gray_opacities.cpp
+  test_epbremsstrahlung_opacities.cpp
   test_gray_s_opacities.cpp
   test_brt_opacities.cpp
   test_thomson_s_opacities.cpp

--- a/test/test_epbremsstrahlung_opacities.cpp
+++ b/test/test_epbremsstrahlung_opacities.cpp
@@ -1,0 +1,171 @@
+// ======================================================================
+// © 2021. Triad National Security, LLC. All rights reserved.  This
+// program was produced under U.S. Government contract
+// 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
+// is operated by Triad National Security, LLC for the U.S.
+// Department of Energy/National Nuclear Security Administration. All
+// rights in the program are reserved by Triad National Security, LLC,
+// and the U.S. Department of Energy/National Nuclear Security
+// Administration. The Government is granted for itself and others
+// acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works,
+// distribute copies to the public, perform publicly and display
+// publicly, and to permit others to do so.
+// ======================================================================
+
+#include <cmath>
+#include <iostream>
+
+#include <catch2/catch.hpp>
+
+#include <ports-of-call/portability.hpp>
+#include <ports-of-call/portable_arrays.hpp>
+#include <spiner/databox.hpp>
+
+#include <singularity-opac/base/indexers.hpp>
+#include <singularity-opac/base/radiation_types.hpp>
+#include <singularity-opac/chebyshev/chebyshev.hpp>
+#include <singularity-opac/constants/constants.hpp>
+#include <singularity-opac/photons/opac_photons.hpp>
+
+using namespace singularity;
+
+using pc = PhysicalConstantsCGS;
+
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+using atomic_view = Kokkos::MemoryTraits<Kokkos::Atomic>;
+#endif
+
+template <typename T>
+PORTABLE_INLINE_FUNCTION T FractionalDifference(const T &a, const T &b) {
+  return 2 * std::abs(b - a) / (std::abs(a) + std::abs(b) + 1e-20);
+}
+constexpr Real EPS_TEST = 1e-3;
+
+TEST_CASE("E-P bremsstrahlung photon opacities", "[EPBremsstrahlungPhotons]") {
+  WHEN("We initialize an electron-proton bremsstrahlung photon opacity") {
+    constexpr Real rho = 1e3;  // g/cc.
+    constexpr Real temp = 1e5; // Kelvin.
+    constexpr Real nu = 3e9;   // Hz. UHF microwave
+
+    photons::Opacity opac_host = photons::EPBremss();
+    photons::Opacity opac = opac_host.GetOnDevice();
+    THEN("The emissivity per nu omega is consistent with the emissity per nu") {
+      int n_wrong_h = 0;
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+      Kokkos::View<int, atomic_view> n_wrong_d("wrong");
+#else
+      PortableMDArray<int> n_wrong_d(&n_wrong_h, 1);
+#endif
+      portableFor(
+          "calc emissivities", 0, 100, PORTABLE_LAMBDA(const int &i) {
+            Real jnu = opac.EmissivityPerNuOmega(rho, temp, nu);
+            Real Jnu = opac.EmissivityPerNu(rho, temp, nu);
+            if (FractionalDifference(Jnu, 4 * M_PI * jnu) > EPS_TEST) {
+              n_wrong_d() += 1;
+            }
+          });
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+      Kokkos::deep_copy(n_wrong_h, n_wrong_d);
+#endif
+      REQUIRE(n_wrong_h == 0);
+    }
+
+    WHEN("We create another opacity object in non-cgs units") {
+      constexpr Real time_unit = 123;
+      constexpr Real mass_unit = 456;
+      constexpr Real length_unit = 789;
+      constexpr Real temp_unit = 276;
+      constexpr Real rho_unit =
+          mass_unit / (length_unit * length_unit * length_unit);
+      constexpr Real j_unit = mass_unit / (length_unit * time_unit * time_unit);
+      photons::Opacity funny_units_host =
+          photons::NonCGSUnits<photons::EPBremss>(photons::EPBremss(),
+                                                  time_unit, mass_unit,
+                                                  length_unit, temp_unit);
+      auto funny_units = funny_units_host.GetOnDevice();
+
+      THEN("We can convert meaningfully into and out of funny units") {
+        int n_wrong_h = 0;
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+        Kokkos::View<int, atomic_view> n_wrong_d("wrong");
+#else
+        PortableMDArray<int> n_wrong_d(&n_wrong_h, 1);
+#endif
+
+        portableFor(
+            "emissivities in funny units", 0, 100,
+            PORTABLE_LAMBDA(const int &i) {
+              Real jnu_funny = funny_units.EmissivityPerNuOmega(
+                  rho / rho_unit, temp / temp_unit, nu * time_unit);
+              Real jnu = opac.EmissivityPerNuOmega(rho, temp, nu);
+              if (FractionalDifference(jnu, jnu_funny * j_unit) > EPS_TEST) {
+                n_wrong_d() += 1;
+              }
+            });
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+        Kokkos::deep_copy(n_wrong_h, n_wrong_d);
+#endif
+        REQUIRE(n_wrong_h == 0);
+      }
+    }
+
+    THEN("We can fill an indexer allocated in a cell") {
+      int n_wrong_h = 0;
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+      Kokkos::View<int, atomic_view> n_wrong_d("wrong");
+#else
+      PortableMDArray<int> n_wrong_d(&n_wrong_h, 1);
+#endif
+      constexpr int nbins = 100;
+      constexpr int ntemps = 100;
+
+      constexpr Real lnu_min = 8;
+      constexpr Real lnu_max = 10;
+      Real nu_min = std::pow(10, lnu_min);
+      Real nu_max = std::pow(10, lnu_max);
+      Real dnu = (lnu_max - lnu_min) / (Real)(nbins - 1);
+
+      constexpr Real lt_min = 2;
+      constexpr Real lt_max = 4;
+      Real dt = (lt_max - lt_min) / (Real)(ntemps - 1);
+
+      Real *nu_bins = (Real *)PORTABLE_MALLOC(nbins * sizeof(Real));
+      Real *temp_bins = (Real *)PORTABLE_MALLOC(ntemps * sizeof(Real));
+      Spiner::DataBox loglin_bins(Spiner::AllocationTarget::Device, ntemps,
+                                  nbins);
+
+      portableFor(
+          "set nu bins", 0, nbins, PORTABLE_LAMBDA(const int &i) {
+            nu_bins[i] = std::pow(10, lnu_min + dnu * i);
+          });
+      portableFor(
+          "set temp bins", 0, ntemps, PORTABLE_LAMBDA(const int &i) {
+            temp_bins[i] = std::pow(10, lt_min + dt * i);
+          });
+
+      portableFor(
+          "Fill the indexers", 0, ntemps, PORTABLE_LAMBDA(const int &i) {
+            Real temp = temp_bins[i];
+            auto bins = loglin_bins.slice(i);
+            indexers::LogLinear J_log(bins, nu_min, nu_max, nbins);
+            opac.EmissivityPerNu(rho, temp, nu_bins, J_log, nbins);
+            Real Jtrue = opac.EmissivityPerNu(rho, temp, nu);
+            if (FractionalDifference(Jtrue, J_log(nu)) > EPS_TEST) {
+              n_wrong_d() += 1;
+            }
+          });
+
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+      Kokkos::deep_copy(n_wrong_h, n_wrong_d);
+#endif
+      REQUIRE(n_wrong_h == 0);
+
+      PORTABLE_FREE(nu_bins);
+      PORTABLE_FREE(temp_bins);
+      free(loglin_bins);
+    }
+
+    opac.Finalize();
+  }
+}

--- a/test/test_mean_opacities.cpp
+++ b/test/test_mean_opacities.cpp
@@ -32,7 +32,9 @@
 #include <singularity-opac/neutrinos/opac_neutrinos.hpp>
 #include <singularity-opac/neutrinos/s_opac_neutrinos.hpp>
 #include <singularity-opac/photons/mean_opacity_photons.hpp>
+#include <singularity-opac/photons/mean_s_opacity_photons.hpp>
 #include <singularity-opac/photons/opac_photons.hpp>
+#include <singularity-opac/photons/s_opac_photons.hpp>
 
 using namespace singularity;
 
@@ -517,6 +519,161 @@ TEST_CASE("Mean photon opacities", "[MeanPhotons]") {
                 rho / rho_unit, temp / temp_unit);
             Real alphaRosselandFunny =
                 funny_units.RosselandMeanAbsorptionCoefficient(
+                    rho / rho_unit, temp / temp_unit);
+            if (FractionalDifference(alphaPlanck, alphaPlanckFunny /
+                                                      length_unit) > EPS_TEST) {
+              n_wrong_d() += 1;
+            }
+            if (FractionalDifference(alphaRosseland,
+                                     alphaRosselandFunny / length_unit) >
+                EPS_TEST) {
+              n_wrong_d() += 1;
+            }
+          });
+
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+      Kokkos::deep_copy(n_wrong_h, n_wrong_d);
+#endif
+      REQUIRE(n_wrong_h == 0);
+    }
+
+    opac.Finalize();
+  }
+}
+
+TEST_CASE("Mean photon scattering opacities", "[MeanPhotonS]") {
+  const std::string grayname = "mean_gray_s.sp5";
+
+  WHEN("We initialize a mean photon scattering opacity") {
+    constexpr Real MeV2K = 1e6 * pc::eV / pc::kb;
+    constexpr Real MeV2Hz = 1e6 * pc::eV / pc::h;
+    constexpr Real rho = 1e0;   // g/cc
+    constexpr Real temp = 1.e5; // K
+    constexpr Real nu = 1.e15;  // Hz
+
+    constexpr int nT = 10;
+    constexpr Real lRhoMin = std::log10(0.1 * rho);
+    constexpr Real lRhoMax = std::log10(10. * rho);
+    constexpr int NRho = 2;
+    constexpr Real lTMin = std::log10(0.1 * temp);
+    constexpr Real lTMax = std::log10(10. * temp);
+    constexpr int NT = 10;
+
+    constexpr Real sigma = 1.e-20;
+
+    constexpr Real avg_particle_mass = pc::mp / 2.;
+
+    photons::GrayS opac_host(sigma, avg_particle_mass);
+    photons::SOpacity opac = opac_host.GetOnDevice();
+
+    photons::MeanSOpacityCGS mean_opac_host(opac_host, lRhoMin, lRhoMax, NRho,
+                                            lTMin, lTMax, NT);
+    auto mean_opac = mean_opac_host.GetOnDevice();
+
+    THEN("The emissivity per nu omega is consistent with the emissity per nu") {
+      int n_wrong_h = 0;
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+      Kokkos::View<int, atomic_view> n_wrong_d("wrong");
+#else
+      PortableMDArray<int> n_wrong_d(&n_wrong_h, 1);
+#endif
+
+      portableFor(
+          "calc mean opacities", 0, 100, PORTABLE_LAMBDA(const int &i) {
+            Real alphaPlanck =
+                mean_opac.PlanckMeanTotalScatteringCoefficient(rho, temp);
+            Real alphaRosseland =
+                mean_opac.PlanckMeanTotalScatteringCoefficient(rho, temp);
+            if (FractionalDifference(sigma * rho / avg_particle_mass,
+                                     alphaPlanck) > EPS_TEST) {
+              n_wrong_d() += 1;
+            }
+            if (FractionalDifference(sigma * rho / avg_particle_mass,
+                                     alphaRosseland) > EPS_TEST) {
+              n_wrong_d() += 1;
+            }
+          });
+
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+      Kokkos::deep_copy(n_wrong_h, n_wrong_d);
+#endif
+      REQUIRE(n_wrong_h == 0);
+    }
+
+#ifdef SPINER_USE_HDF
+    THEN("We can save to disk and reload") {
+      mean_opac.Save(grayname);
+      photons::MeanSOpacityCGS mean_opac_host_load(grayname);
+      AND_THEN("The reloaded table matches the gray opacities") {
+
+        auto mean_opac_load = mean_opac_host_load.GetOnDevice();
+
+        int n_wrong = 0;
+        portableReduce(
+            "rebuilt table vs gray", 0, NRho, 0, NT, 0, 0,
+            PORTABLE_LAMBDA(const int iRho, const int iT, const int igarbage, int &accumulate) {
+              const Real lRho =
+                  lRhoMin + (lRhoMax - lRhoMin) / (NRho - 1) * iRho;
+              const Real rho = std::pow(10, lRho);
+              const Real lT = lTMin + (lTMax - lTMin) / (NT - 1) * iT;
+              const Real T = std::pow(10, lT);
+
+              const Real kappaPgray =
+                  mean_opac.PlanckMeanTotalScatteringCoefficient(rho, T);
+              const Real kappaPload =
+                  mean_opac_load.PlanckMeanTotalScatteringCoefficient(rho, T);
+
+              const Real kappaRgray =
+                  mean_opac.RosselandMeanTotalScatteringCoefficient(rho, T);
+              const Real kappaRload =
+                  mean_opac_load.RosselandMeanTotalScatteringCoefficient(rho,
+                                                                         T);
+
+              if (IsWrong(kappaPgray, kappaPload)) {
+                accumulate += 1;
+              }
+              if (IsWrong(kappaRgray, kappaRload)) {
+                accumulate += 1;
+              }
+            },
+            n_wrong);
+        REQUIRE(n_wrong == 0);
+      }
+    }
+#endif
+
+    THEN("We can create an opacity object with funny units") {
+      constexpr Real time_unit = 123;
+      constexpr Real mass_unit = 456;
+      constexpr Real length_unit = 789;
+      constexpr Real temp_unit = 276;
+      constexpr Real rho_unit =
+          mass_unit / (length_unit * length_unit * length_unit);
+
+      auto funny_units_host = photons::MeanNonCGSUnitsS<photons::MeanSOpacity>(
+          std::forward<photons::MeanSOpacity>(mean_opac_host), time_unit,
+          mass_unit, length_unit, temp_unit);
+
+      auto funny_units = funny_units_host.GetOnDevice();
+
+      int n_wrong_h = 0;
+#ifdef PORTABILITY_STRATEGY_KOKKOS
+      Kokkos::View<int, atomic_view> n_wrong_d("wrong");
+#else
+      PortableMDArray<int> n_wrong_d(&n_wrong_h, 1);
+#endif
+
+      portableFor(
+          "compare different units", 0, 100, PORTABLE_LAMBDA(const int &i) {
+            Real alphaPlanck =
+                mean_opac.PlanckMeanTotalScatteringCoefficient(rho, temp);
+            Real alphaRosseland =
+                mean_opac.RosselandMeanTotalScatteringCoefficient(rho, temp);
+            Real alphaPlanckFunny =
+                funny_units.PlanckMeanTotalScatteringCoefficient(
+                    rho / rho_unit, temp / temp_unit);
+            Real alphaRosselandFunny =
+                funny_units.RosselandMeanTotalScatteringCoefficient(
                     rho / rho_unit, temp / temp_unit);
             if (FractionalDifference(alphaPlanck, alphaPlanckFunny /
                                                       length_unit) > EPS_TEST) {

--- a/test/test_thomson_s_opacities.cpp
+++ b/test/test_thomson_s_opacities.cpp
@@ -26,7 +26,6 @@
 #include <singularity-opac/base/radiation_types.hpp>
 #include <singularity-opac/chebyshev/chebyshev.hpp>
 #include <singularity-opac/constants/constants.hpp>
-#include <singularity-opac/neutrinos/s_opac_neutrinos.hpp>
 #include <singularity-opac/photons/s_opac_photons.hpp>
 
 using namespace singularity;
@@ -43,90 +42,8 @@ PORTABLE_INLINE_FUNCTION T FractionalDifference(const T &a, const T &b) {
 }
 constexpr Real EPS_TEST = 1e-3;
 
-TEST_CASE("Gray neutrino scattering opacities", "[GraySNeutrinos]") {
-  WHEN("We initialize a gray neutrino scattering opacity") {
-    constexpr Real MeV2K = 1e6 * pc::eV / pc::kb;
-    constexpr Real MeV2Hz = 1e6 * pc::eV / pc::h;
-    constexpr Real rho = 1e11;        // g/cc
-    constexpr Real temp = 10 * MeV2K; // 10 MeV
-    constexpr Real Ye = 0.1;
-    constexpr RadiationType type = RadiationType::NU_ELECTRON;
-    constexpr Real nu = 1.25 * MeV2Hz; // 1 MeV
-
-    constexpr Real avg_particle_mass = pc::mp;
-
-    neutrinos::GrayS opac_host(1, avg_particle_mass);
-    neutrinos::SOpacity opac = opac_host.GetOnDevice();
-
-    THEN("The emissivity per nu omega is consistent with the emissity per nu") {
-      int n_wrong_h = 0;
-#ifdef PORTABILITY_STRATEGY_KOKKOS
-      Kokkos::View<int, atomic_view> n_wrong_d("wrong");
-#else
-      PortableMDArray<int> n_wrong_d(&n_wrong_h, 1);
-#endif
-
-      portableFor(
-          "calc s opacities", 0, 100, PORTABLE_LAMBDA(const int &i) {
-            Real kappa =
-                opac.TotalScatteringCoefficient(rho, temp, Ye, type, nu);
-            Real sigma = opac.TotalCrossSection(rho, temp, Ye, type, nu);
-            if (FractionalDifference(kappa, rho / avg_particle_mass * sigma) >
-                EPS_TEST) {
-              n_wrong_d() += 1;
-            }
-          });
-
-#ifdef PORTABILITY_STRATEGY_KOKKOS
-      Kokkos::deep_copy(n_wrong_h, n_wrong_d);
-#endif
-      REQUIRE(n_wrong_h == 0);
-    }
-
-    WHEN("We create a gray opacity object in non-cgs units") {
-      constexpr Real time_unit = 123;
-      constexpr Real mass_unit = 456;
-      constexpr Real length_unit = 789;
-      constexpr Real temp_unit = 276;
-      constexpr Real rho_unit =
-          mass_unit / (length_unit * length_unit * length_unit);
-      constexpr Real kappa_unit = 1. / length_unit;
-      neutrinos::SOpacity funny_units_host =
-          neutrinos::NonCGSUnitsS<neutrinos::GrayS>(
-              neutrinos::GrayS(1, avg_particle_mass), time_unit, mass_unit,
-              length_unit, temp_unit);
-      auto funny_units = funny_units_host.GetOnDevice();
-
-      THEN("We can convert meaningfully into and out of funny units") {
-        int n_wrong_h = 0;
-#ifdef PORTABILITY_STRATEGY_KOKKOS
-        Kokkos::View<int, atomic_view> n_wrong_d("wrong");
-#else
-        PortableMDArray<int> n_wrong_d(&n_wrong_h, 1);
-#endif
-
-        portableFor(
-            "opacities in funny units", 0, 100, PORTABLE_LAMBDA(const int &i) {
-              Real kappa_funny = funny_units.TotalScatteringCoefficient(
-                  rho / rho_unit, temp / temp_unit, Ye, type, nu * time_unit);
-              Real kappa =
-                  opac.TotalScatteringCoefficient(rho, temp, Ye, type, nu);
-              if (FractionalDifference(kappa, kappa_funny * kappa_unit) >
-                  EPS_TEST) {
-                n_wrong_d() += 1;
-              }
-            });
-#ifdef PORTABILITY_STRATEGY_KOKKOS
-        Kokkos::deep_copy(n_wrong_h, n_wrong_d);
-#endif
-        REQUIRE(n_wrong_h == 0);
-      }
-    }
-  }
-}
-
-TEST_CASE("Gray photon scattering opacities", "[GraySPhotons]") {
-  WHEN("We initialize a gray photon scattering opacity") {
+TEST_CASE("Thomson photon scattering opacities", "[ThomsonSPhotons]") {
+  WHEN("We initialize a Thomson photon scattering opacity") {
     constexpr Real MeV2K = 1e6 * pc::eV / pc::kb;
     constexpr Real MeV2Hz = 1e6 * pc::eV / pc::h;
     constexpr Real rho = 1e0;   // g/cc
@@ -135,8 +52,11 @@ TEST_CASE("Gray photon scattering opacities", "[GraySPhotons]") {
 
     constexpr Real avg_particle_mass = pc::mp / 2.;
 
-    photons::GrayS opac_host(1, avg_particle_mass);
+    photons::ThomsonS opac_host(avg_particle_mass);
     photons::SOpacity opac = opac_host.GetOnDevice();
+
+    const Real sigmaT =
+        8. * M_PI / 3. * std::pow(pc::alpha * pc::hbar / (pc::me * pc::c), 2);
 
     THEN("The emissivity per nu omega is consistent with the emissity per nu") {
       int n_wrong_h = 0;
@@ -148,11 +68,13 @@ TEST_CASE("Gray photon scattering opacities", "[GraySPhotons]") {
 
       portableFor(
           "calc s opacities", 0, 100, PORTABLE_LAMBDA(const int &i) {
-            Real kappa =
-                opac.TotalScatteringCoefficient(rho, temp, nu);
+            Real kappa = opac.TotalScatteringCoefficient(rho, temp, nu);
             Real sigma = opac.TotalCrossSection(rho, temp, nu);
             if (FractionalDifference(kappa, rho / avg_particle_mass * sigma) >
                 EPS_TEST) {
+              n_wrong_d() += 1;
+            }
+            if (FractionalDifference(sigma, sigmaT) > EPS_TEST) {
               n_wrong_d() += 1;
             }
           });
@@ -172,8 +94,8 @@ TEST_CASE("Gray photon scattering opacities", "[GraySPhotons]") {
           mass_unit / (length_unit * length_unit * length_unit);
       constexpr Real kappa_unit = 1. / length_unit;
       photons::SOpacity funny_units_host =
-          photons::NonCGSUnitsS<photons::GrayS>(
-              photons::GrayS(1, avg_particle_mass), time_unit, mass_unit,
+          photons::NonCGSUnitsS<photons::ThomsonS>(
+              photons::ThomsonS(avg_particle_mass), time_unit, mass_unit,
               length_unit, temp_unit);
       auto funny_units = funny_units_host.GetOnDevice();
 
@@ -189,8 +111,7 @@ TEST_CASE("Gray photon scattering opacities", "[GraySPhotons]") {
             "opacities in funny units", 0, 100, PORTABLE_LAMBDA(const int &i) {
               Real kappa_funny = funny_units.TotalScatteringCoefficient(
                   rho / rho_unit, temp / temp_unit, nu * time_unit);
-              Real kappa =
-                  opac.TotalScatteringCoefficient(rho, temp, nu);
+              Real kappa = opac.TotalScatteringCoefficient(rho, temp, nu);
               if (FractionalDifference(kappa, kappa_funny * kappa_unit) >
                   EPS_TEST) {
                 n_wrong_d() += 1;


### PR DESCRIPTION
I add photon variants for Thomson scattering opacity and electron-proton bremsstrahlung opacity. 

Along the way I add a mean scattering class to photons analogous to the recently added mean scattering class for neutrinos #34