### PR TITLE
Additional Rosseland opacity fixes

### DIFF
--- a/singularity-opac/neutrinos/mean_opacity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/mean_opacity_neutrinos.hpp
@@ -46,8 +46,9 @@ class MeanOpacity {
               const int NRho, const Real lTMin, const Real lTMax, const int NT,
               const Real YeMin, const Real YeMax, const int NYe,
               Real *lambda = nullptr) {
-    MeanOpacityImpl<Opacity, true>(opac, lRhoMin, lRhoMax, NRho, lTMin, lTMax, NT, YeMin, YeMax,
-                NYe, -1., -1., 100, lambda);
+    MeanOpacityImpl<Opacity, true>(opac, lRhoMin, lRhoMax, NRho, lTMin, lTMax,
+                                   NT, YeMin, YeMax, NYe, -1., -1., 100,
+                                   lambda);
   }
 
   template <typename Opacity>
@@ -55,15 +56,17 @@ class MeanOpacity {
               const int NRho, const Real lTMin, const Real lTMax, const int NT,
               const Real YeMin, const Real YeMax, const int NYe, Real lNuMin,
               Real lNuMax, const int NNu, Real *lambda = nullptr) {
-    MeanOpacityImpl<Opacity, false>(opac, lRhoMin, lRhoMax, NRho, lTMin, lTMax, NT, YeMin, YeMax,
-                NYe, lNuMin, lNuMax, NNu, lambda);
+    MeanOpacityImpl<Opacity, false>(opac, lRhoMin, lRhoMax, NRho, lTMin, lTMax,
+                                    NT, YeMin, YeMax, NYe, lNuMin, lNuMax, NNu,
+                                    lambda);
   }
 
   template <typename Opacity, bool AUTOFREQ>
-  MeanOpacityImpl(const Opacity &opac, const Real lRhoMin, const Real lRhoMax,
-              const int NRho, const Real lTMin, const Real lTMax, const int NT,
-              const Real YeMin, const Real YeMax, const int NYe, Real lNuMin,
-              Real lNuMax, const int NNu, Real *lambda = nullptr) {
+  void MeanOpacityImpl(const Opacity &opac, const Real lRhoMin,
+                       const Real lRhoMax, const int NRho, const Real lTMin,
+                       const Real lTMax, const int NT, const Real YeMin,
+                       const Real YeMax, const int NYe, Real lNuMin,
+                       Real lNuMax, const int NNu, Real *lambda = nullptr) {
     lkappaPlanck_.resize(NRho, NT, NYe, NEUTRINO_NTYPES);
     // index 0 is the species and is not interpolatable
     lkappaPlanck_.setRange(1, YeMin, YeMax, NYe);
@@ -86,7 +89,8 @@ class MeanOpacity {
             Real kappaPlanckDenom = 0.;
             Real kappaRosselandNum = 0.;
             Real kappaRosselandDenom = 0.;
-            // Choose default temperature-specific frequency grid if frequency grid not specified
+            // Choose default temperature-specific frequency grid if frequency
+            // grid not specified
             if (AUTOFREQ) {
               lNuMin = toLog_(1.e-3 * pc::kb * fromLog_(lTMin) / pc::h);
               lNuMax = toLog_(1.e3 * pc::kb * fromLog_(lTMax) / pc::h);
@@ -121,7 +125,6 @@ class MeanOpacity {
                     ? singularity_opac::robust::ratio(kappaRosselandDenom,
                                                       kappaRosselandNum)
                     : 0.;
-            printf("kappas: %e %e\n", kappaPlanck, kappaRosseland);
 
             lkappaPlanck_(iRho, iT, iYe, idx) = toLog_(kappaPlanck);
             lkappaRosseland_(iRho, iT, iYe, idx) = toLog_(kappaRosseland);

--- a/singularity-opac/photons/mean_opacity_photons.hpp
+++ b/singularity-opac/photons/mean_opacity_photons.hpp
@@ -58,10 +58,10 @@ class MeanOpacity {
   }
 
   template <typename Opacity, bool AUTOFREQ>
-  MeanOpacityImpl(const Opacity &opac, const Real lRhoMin, const Real lRhoMax,
-                  const int NRho, const Real lTMin, const Real lTMax,
-                  const int NT, Real lNuMin, Real lNuMax, const int NNu,
-                  Real *lambda = nullptr) {
+  void MeanOpacityImpl(const Opacity &opac, const Real lRhoMin,
+                       const Real lRhoMax, const int NRho, const Real lTMin,
+                       const Real lTMax, const int NT, Real lNuMin, Real lNuMax,
+                       const int NNu, Real *lambda = nullptr) {
     lkappaPlanck_.resize(NRho, NT);
     lkappaPlanck_.setRange(0, lTMin, lTMax, NT);
     lkappaPlanck_.setRange(1, lRhoMin, lRhoMax, NRho);

--- a/singularity-opac/photons/mean_opacity_photons.hpp
+++ b/singularity-opac/photons/mean_opacity_photons.hpp
@@ -45,78 +45,16 @@ class MeanOpacity {
   MeanOpacity(const Opacity &opac, const Real lRhoMin, const Real lRhoMax,
               const int NRho, const Real lTMin, const Real lTMax, const int NT,
               Real *lambda = nullptr) {
-    MeanOpacityImpl<Opacity, true>(opac, lRhoMin, lRhoMax, NRho, lTMin, lTMax,
-                                   NT, -1., -1., 100, lambda);
+    MeanOpacityImpl_<Opacity, true>(opac, lRhoMin, lRhoMax, NRho, lTMin, lTMax,
+                                    NT, -1., -1., 100, lambda);
   }
 
   template <typename Opacity>
   MeanOpacity(const Opacity &opac, const Real lRhoMin, const Real lRhoMax,
               const int NRho, const Real lTMin, const Real lTMax, const int NT,
               Real lNuMin, Real lNuMax, const int NNu, Real *lambda = nullptr) {
-    MeanOpacityImpl<Opacity, false>(opac, lRhoMin, lRhoMax, NRho, lTMin, lTMax,
-                                    NT, lNuMin, lNuMax, NNu, lambda);
-  }
-
-  template <typename Opacity, bool AUTOFREQ>
-  void MeanOpacityImpl(const Opacity &opac, const Real lRhoMin,
-                       const Real lRhoMax, const int NRho, const Real lTMin,
-                       const Real lTMax, const int NT, Real lNuMin, Real lNuMax,
-                       const int NNu, Real *lambda = nullptr) {
-    lkappaPlanck_.resize(NRho, NT);
-    lkappaPlanck_.setRange(0, lTMin, lTMax, NT);
-    lkappaPlanck_.setRange(1, lRhoMin, lRhoMax, NRho);
-    lkappaRosseland_.copyMetadata(lkappaPlanck_);
-
-    // Fill tables
-    for (int iRho = 0; iRho < NRho; ++iRho) {
-      Real lRho = lkappaPlanck_.range(1).x(iRho);
-      Real rho = fromLog_(lRho);
-      for (int iT = 0; iT < NT; ++iT) {
-        Real lT = lkappaPlanck_.range(0).x(iT);
-        Real T = fromLog_(lT);
-        Real kappaPlanckNum = 0.;
-        Real kappaPlanckDenom = 0.;
-        Real kappaRosselandNum = 0.;
-        Real kappaRosselandDenom = 0.;
-        if (AUTOFREQ) {
-          lNuMin = toLog_(1.e-3 * pc::kb * fromLog_(lTMin) / pc::h);
-          lNuMax = toLog_(1.e3 * pc::kb * fromLog_(lTMax) / pc::h);
-        }
-        const Real dlnu = (lNuMax - lNuMin) / (NNu - 1);
-        // Integrate over frequency
-        for (int inu = 0; inu < NNu; ++inu) {
-          const Real weight =
-              (inu == 0 || inu == NNu - 1) ? 0.5 : 1.; // Trapezoidal rule
-          const Real lnu = lNuMin + inu * dlnu;
-          const Real nu = fromLog_(lnu);
-          const Real alpha = opac.AbsorptionCoefficient(rho, T, nu, lambda);
-          const Real B = opac.ThermalDistributionOfTNu(T, nu);
-          const Real dBdT = opac.DThermalDistributionOfTNuDT(T, nu);
-          kappaPlanckNum += weight * alpha / rho * B * nu * dlnu;
-          kappaPlanckDenom += weight * B * nu * dlnu;
-
-          if (alpha > singularity_opac::robust::SMALL()) {
-            kappaRosselandNum += weight *
-                                 singularity_opac::robust::ratio(rho, alpha) *
-                                 dBdT * nu * dlnu;
-            kappaRosselandDenom += weight * dBdT * nu * dlnu;
-          }
-        }
-
-        Real kappaPlanck =
-            singularity_opac::robust::ratio(kappaPlanckNum, kappaPlanckDenom);
-        Real kappaRosseland = kappaPlanck > singularity_opac::robust::SMALL()
-                                  ? singularity_opac::robust::ratio(
-                                        kappaRosselandDenom, kappaRosselandNum)
-                                  : 0.;
-        lkappaPlanck_(iRho, iT) = toLog_(kappaPlanck);
-        lkappaRosseland_(iRho, iT) = toLog_(kappaRosseland);
-        if (std::isnan(lkappaPlanck_(iRho, iT)) ||
-            std::isnan(lkappaRosseland_(iRho, iT))) {
-          OPAC_ERROR("photons::MeanOpacity: NAN in opacity evaluations");
-        }
-      }
-    }
+    MeanOpacityImpl_<Opacity, false>(opac, lRhoMin, lRhoMax, NRho, lTMin, lTMax,
+                                     NT, lNuMin, lNuMax, NNu, lambda);
   }
 
 #ifdef SPINER_USE_HDF
@@ -180,6 +118,67 @@ class MeanOpacity {
   }
 
  private:
+  template <typename Opacity, bool AUTOFREQ>
+  void MeanOpacityImpl_(const Opacity &opac, const Real lRhoMin,
+                        const Real lRhoMax, const int NRho, const Real lTMin,
+                        const Real lTMax, const int NT, Real lNuMin,
+                        Real lNuMax, const int NNu, Real *lambda = nullptr) {
+    lkappaPlanck_.resize(NRho, NT);
+    lkappaPlanck_.setRange(0, lTMin, lTMax, NT);
+    lkappaPlanck_.setRange(1, lRhoMin, lRhoMax, NRho);
+    lkappaRosseland_.copyMetadata(lkappaPlanck_);
+
+    // Fill tables
+    for (int iRho = 0; iRho < NRho; ++iRho) {
+      Real lRho = lkappaPlanck_.range(1).x(iRho);
+      Real rho = fromLog_(lRho);
+      for (int iT = 0; iT < NT; ++iT) {
+        Real lT = lkappaPlanck_.range(0).x(iT);
+        Real T = fromLog_(lT);
+        Real kappaPlanckNum = 0.;
+        Real kappaPlanckDenom = 0.;
+        Real kappaRosselandNum = 0.;
+        Real kappaRosselandDenom = 0.;
+        if (AUTOFREQ) {
+          lNuMin = toLog_(1.e-3 * pc::kb * fromLog_(lTMin) / pc::h);
+          lNuMax = toLog_(1.e3 * pc::kb * fromLog_(lTMax) / pc::h);
+        }
+        const Real dlnu = (lNuMax - lNuMin) / (NNu - 1);
+        // Integrate over frequency
+        for (int inu = 0; inu < NNu; ++inu) {
+          const Real weight =
+              (inu == 0 || inu == NNu - 1) ? 0.5 : 1.; // Trapezoidal rule
+          const Real lnu = lNuMin + inu * dlnu;
+          const Real nu = fromLog_(lnu);
+          const Real alpha = opac.AbsorptionCoefficient(rho, T, nu, lambda);
+          const Real B = opac.ThermalDistributionOfTNu(T, nu);
+          const Real dBdT = opac.DThermalDistributionOfTNuDT(T, nu);
+          kappaPlanckNum += weight * alpha / rho * B * nu * dlnu;
+          kappaPlanckDenom += weight * B * nu * dlnu;
+
+          if (alpha > singularity_opac::robust::SMALL()) {
+            kappaRosselandNum += weight *
+                                 singularity_opac::robust::ratio(rho, alpha) *
+                                 dBdT * nu * dlnu;
+            kappaRosselandDenom += weight * dBdT * nu * dlnu;
+          }
+        }
+
+        Real kappaPlanck =
+            singularity_opac::robust::ratio(kappaPlanckNum, kappaPlanckDenom);
+        Real kappaRosseland = kappaPlanck > singularity_opac::robust::SMALL()
+                                  ? singularity_opac::robust::ratio(
+                                        kappaRosselandDenom, kappaRosselandNum)
+                                  : 0.;
+        lkappaPlanck_(iRho, iT) = toLog_(kappaPlanck);
+        lkappaRosseland_(iRho, iT) = toLog_(kappaRosseland);
+        if (std::isnan(lkappaPlanck_(iRho, iT)) ||
+            std::isnan(lkappaRosseland_(iRho, iT))) {
+          OPAC_ERROR("photons::MeanOpacity: NAN in opacity evaluations");
+        }
+      }
+    }
+  }
   PORTABLE_INLINE_FUNCTION Real toLog_(const Real x) const {
     return std::log10(std::abs(x) + EPS);
   }

--- a/singularity-opac/photons/mean_opacity_photons.hpp
+++ b/singularity-opac/photons/mean_opacity_photons.hpp
@@ -58,9 +58,10 @@ class MeanOpacity {
   }
 
   template <typename Opacity, bool AUTOFREQ>
-  MeanOpacity(const Opacity &opac, const Real lRhoMin, const Real lRhoMax,
-              const int NRho, const Real lTMin, const Real lTMax, const int NT,
-              Real lNuMin, Real lNuMax, const int NNu, Real *lambda = nullptr) {
+  MeanOpacityImpl(const Opacity &opac, const Real lRhoMin, const Real lRhoMax,
+                  const int NRho, const Real lTMin, const Real lTMax,
+                  const int NT, Real lNuMin, Real lNuMax, const int NNu,
+                  Real *lambda = nullptr) {
     lkappaPlanck_.resize(NRho, NT);
     lkappaPlanck_.setRange(0, lTMin, lTMax, NT);
     lkappaPlanck_.setRange(1, lRhoMin, lRhoMax, NRho);
@@ -102,10 +103,12 @@ class MeanOpacity {
           }
         }
 
-        Real kappaPlanck = (
+        Real kappaPlanck =
             singularity_opac::robust::ratio(kappaPlanckNum, kappaPlanckDenom);
-        Real kappaRosseland = kappaPlanck > singularity_opac::robust::SMALL() ? singularity_opac::robust::ratio(
-            kappaRosselandDenom, kappaRosselandNum) : 0.;
+        Real kappaRosseland = kappaPlanck > singularity_opac::robust::SMALL()
+                                  ? singularity_opac::robust::ratio(
+                                        kappaRosselandDenom, kappaRosselandNum)
+                                  : 0.;
         lkappaPlanck_(iRho, iT) = toLog_(kappaPlanck);
         lkappaRosseland_(iRho, iT) = toLog_(kappaRosseland);
         if (std::isnan(lkappaPlanck_(iRho, iT)) ||

--- a/singularity-opac/photons/mean_s_opacity_photons.hpp
+++ b/singularity-opac/photons/mean_s_opacity_photons.hpp
@@ -49,18 +49,21 @@ class MeanSOpacity {
     MeanSOpacityImpl<SOpacity, true>(s_opac, lRhoMin, lRhoMax, NRho, lTMin,
                                      lTMax, NT, -1., -1., 100, lambda);
   }
+
   template <typename SOpacity>
-  MeanSOpacity(const SOpacity &s_opac, const Real lRhoMin, const Real lRhoMax,
-               const int NRho, const Real lTMin, const Real lTMax, const int NT,
-               Real lNuMin, lNuMax, NNu, Real *lambda = nullptr) {
-    MeanSOpacityImpl<SOpacity, false>(s_opac, lRhoMin, lRhoMax, NRho, lTMin,
-                                      lTMax, NT, lNuMin, lNuMax, NNu, lambda);
-  }
-  template <typename SOpacity, bool AUTOFREQ>
   MeanSOpacity(const SOpacity &s_opac, const Real lRhoMin, const Real lRhoMax,
                const int NRho, const Real lTMin, const Real lTMax, const int NT,
                Real lNuMin, Real lNuMax, const int NNu,
                Real *lambda = nullptr) {
+    MeanSOpacityImpl<SOpacity, false>(s_opac, lRhoMin, lRhoMax, NRho, lTMin,
+                                      lTMax, NT, lNuMin, lNuMax, NNu, lambda);
+  }
+
+  template <typename SOpacity, bool AUTOFREQ>
+  MeanSOpacityImpl(const SOpacity &s_opac, const Real lRhoMin,
+                   const Real lRhoMax, const int NRho, const Real lTMin,
+                   const Real lTMax, const int NT, Real lNuMin, Real lNuMax,
+                   const int NNu, Real *lambda = nullptr) {
     ThermalDistribution dist;
 
     lkappaPlanck_.resize(NRho, NT);
@@ -105,12 +108,12 @@ class MeanSOpacity {
           }
         }
 
-        kappaPlanck =
+        Real kappaPlanck =
             singularity_opac::robust::ratio(kappaPlanckNum, kappaPlanckDenom);
-        kappaRosseland = kappaPlanck > singularity_opac::robust::SMALL()
-                             ? singularity_opac::robust::ratio(
-                                   kappaRosselandDenom, kappaRosselandNum)
-                             : 0.;
+        Real kappaRosseland = kappaPlanck > singularity_opac::robust::SMALL()
+                                  ? singularity_opac::robust::ratio(
+                                        kappaRosselandDenom, kappaRosselandNum)
+                                  : 0.;
         lkappaPlanck_(iRho, iT) = toLog_(kappaPlanck);
         lkappaRosseland_(iRho, iT) = toLog_(kappaRosseland);
         if (std::isnan(lkappaPlanck_(iRho, iT)) ||

--- a/singularity-opac/photons/mean_s_opacity_photons.hpp
+++ b/singularity-opac/photons/mean_s_opacity_photons.hpp
@@ -60,10 +60,10 @@ class MeanSOpacity {
   }
 
   template <typename SOpacity, bool AUTOFREQ>
-  MeanSOpacityImpl(const SOpacity &s_opac, const Real lRhoMin,
-                   const Real lRhoMax, const int NRho, const Real lTMin,
-                   const Real lTMax, const int NT, Real lNuMin, Real lNuMax,
-                   const int NNu, Real *lambda = nullptr) {
+  void MeanSOpacityImpl(const SOpacity &s_opac, const Real lRhoMin,
+                        const Real lRhoMax, const int NRho, const Real lTMin,
+                        const Real lTMax, const int NT, Real lNuMin,
+                        Real lNuMax, const int NNu, Real *lambda = nullptr) {
     ThermalDistribution dist;
 
     lkappaPlanck_.resize(NRho, NT);


### PR DESCRIPTION
I was still running into `infinity` values from the Rosseland mean opacity so I modified the code to only compute the integrand if `alpha > singularity_opac::robust::SMALL()` for that support point. 

Along the way I cleaned up the code for the trapezoidal rule, reducing redundant opacity evaluations. 

Mean opacities can also now be evaluated either with a default per-rho, T, Ye frequency range, or with a common frequency range specified by an overloaded constructor