### PR TITLE
exp - 1 -> expm1

### DIFF
--- a/singularity-opac/photons/thermal_distributions_photons.hpp
+++ b/singularity-opac/photons/thermal_distributions_photons.hpp
@@ -32,7 +32,7 @@ struct PlanckDistribution {
                                 Real *lambda = nullptr) const {
     Real x = pc::h * nu / (pc::kb * temp);
     Real Bnu =
-        (2. * pc::h * nu * nu * nu / (pc::c * pc::c)) * 1. / (std::expm1(x));
+        (2. * pc::h * nu * nu * nu / (pc::c * pc::c)) * 1. / std::expm1(x);
     return Bnu;
   }
   PORTABLE_INLINE_FUNCTION
@@ -41,7 +41,7 @@ struct PlanckDistribution {
     Real x = pc::h * nu / (pc::kb * temp);
     Real dBnudT = (2. * pc::h * pc::h * nu * nu * nu * nu /
                    (temp * temp * pc::c * pc::c * pc::kb)) *
-                  1. / (std::expm1(x));
+                  1. / std::expm1(x);
     return dBnudT;
   }
   PORTABLE_INLINE_FUNCTION

--- a/singularity-opac/photons/thermal_distributions_photons.hpp
+++ b/singularity-opac/photons/thermal_distributions_photons.hpp
@@ -32,7 +32,7 @@ struct PlanckDistribution {
                                 Real *lambda = nullptr) const {
     Real x = pc::h * nu / (pc::kb * temp);
     Real Bnu =
-        (2. * pc::h * nu * nu * nu / (pc::c * pc::c)) * 1. / (std::exp(x) - 1.);
+        (2. * pc::h * nu * nu * nu / (pc::c * pc::c)) * 1. / (std::expm1(x));
     return Bnu;
   }
   PORTABLE_INLINE_FUNCTION
@@ -41,7 +41,7 @@ struct PlanckDistribution {
     Real x = pc::h * nu / (pc::kb * temp);
     Real dBnudT = (2. * pc::h * pc::h * nu * nu * nu * nu /
                    (temp * temp * pc::c * pc::c * pc::kb)) *
-                  1. / (std::exp(x) + -1.);
+                  1. / (std::expm1(x));
     return dBnudT;
   }
   PORTABLE_INLINE_FUNCTION


### PR DESCRIPTION
For small `x = h nu / (k T)`, the expression `1 / (exp(-x) - 1)` in the Planck function can produce infinities. Switching from `exp(-x) - 1` to `expm1(-x)` solves this. 