### PR TITLE
Fix unset unit conversions

### DIFF
--- a/singularity-opac/neutrinos/s_opac_neutrinos.hpp
+++ b/singularity-opac/neutrinos/s_opac_neutrinos.hpp
@@ -25,7 +25,6 @@
 namespace singularity {
 namespace neutrinos {
 
-// TODO(JMM): Include chemical potential
 using ScaleFreeS = GraySOpacity<PhysicalConstantsUnity>;
 using GrayS = GraySOpacity<>;
 

--- a/singularity-opac/photons/non_cgs_photons.hpp
+++ b/singularity-opac/photons/non_cgs_photons.hpp
@@ -38,7 +38,10 @@ class NonCGSUnits {
         freq_unit_(1. / time_unit_),
         inv_emiss_unit_(length_unit_ * time_unit_ * time_unit_ / mass_unit_),
         inv_num_emiss_unit_(length_unit_ * length_unit_ * length_unit_ *
-                            time_unit_) {}
+                            time_unit_),
+        inv_intensity_unit_(time_unit_ * time_unit_ / mass_unit_),
+        inv_energy_dens_unit_(time_unit_ * time_unit_ * length_unit_ /
+                              mass_unit_) {}
 
   auto GetOnDevice() {
     return NonCGSUnits<Opac>(opac_.GetOnDevice(), time_unit_, mass_unit_,


### PR DESCRIPTION
Somehow, I left some unit conversions in the non-cgs photons class unset. This PR fixes that.