### PR TITLE
Fix default constructors

### DIFF
--- a/singularity-opac/neutrinos/mean_neutrino_s_variant.hpp
+++ b/singularity-opac/neutrinos/mean_neutrino_s_variant.hpp
@@ -42,8 +42,7 @@ class MeanSVariant {
   PORTABLE_FUNCTION MeanSVariant(Choice &&choice)
       : s_opac_(std::forward<Choice>(choice)) {}
 
-  PORTABLE_FUNCTION
-  MeanSVariant() noexcept = default;
+  MeanSVariant() = default;
 
   template <
       typename Choice,
@@ -77,7 +76,8 @@ class MeanSVariant {
       const RadiationType type) const {
     return mpark::visit(
         [=](const auto &s_opac) {
-          return s_opac.PlanckMeanTotalScatteringCoefficient(rho, temp, Ye, type);
+          return s_opac.PlanckMeanTotalScatteringCoefficient(rho, temp, Ye,
+                                                             type);
         },
         s_opac_);
   }
@@ -86,7 +86,8 @@ class MeanSVariant {
       const RadiationType type) const {
     return mpark::visit(
         [=](const auto &s_opac) {
-          return s_opac.RosselandMeanTotalScatteringCoefficient(rho, temp, Ye, type);
+          return s_opac.RosselandMeanTotalScatteringCoefficient(rho, temp, Ye,
+                                                                type);
         },
         s_opac_);
   }

--- a/singularity-opac/neutrinos/mean_neutrino_variant.hpp
+++ b/singularity-opac/neutrinos/mean_neutrino_variant.hpp
@@ -42,8 +42,7 @@ class MeanVariant {
   PORTABLE_FUNCTION MeanVariant(Choice &&choice)
       : opac_(std::forward<Choice>(choice)) {}
 
-  PORTABLE_FUNCTION
-  MeanVariant() noexcept = default;
+  MeanVariant() = default;
 
   template <
       typename Choice,
@@ -71,7 +70,8 @@ class MeanVariant {
   }
 
   PORTABLE_INLINE_FUNCTION Real PlanckMeanAbsorptionCoefficient(
-      const Real rho, const Real temp, const Real Ye, const RadiationType type) const {
+      const Real rho, const Real temp, const Real Ye,
+      const RadiationType type) const {
     return mpark::visit(
         [=](const auto &opac) {
           return opac.PlanckMeanAbsorptionCoefficient(rho, temp, Ye, type);
@@ -79,7 +79,8 @@ class MeanVariant {
         opac_);
   }
   PORTABLE_INLINE_FUNCTION Real RosselandMeanAbsorptionCoefficient(
-      const Real rho, const Real temp, const Real Ye, const RadiationType type) const {
+      const Real rho, const Real temp, const Real Ye,
+      const RadiationType type) const {
     return mpark::visit(
         [=](const auto &opac) {
           return opac.RosselandMeanAbsorptionCoefficient(rho, temp, Ye, type);
@@ -90,11 +91,10 @@ class MeanVariant {
   inline void Finalize() noexcept {
     return mpark::visit([](auto &opac) { return opac.Finalize(); }, opac_);
   }
-
 };
 
-} // impl
-}
-}
+} // namespace impl
+} // namespace neutrinos
+} // namespace singularity
 
 #endif // SINGULARITY_OPAC_NEUTRINOS_MEAN_NEUTRINO_VARIANT_

--- a/singularity-opac/neutrinos/neutrino_s_variant.hpp
+++ b/singularity-opac/neutrinos/neutrino_s_variant.hpp
@@ -44,8 +44,7 @@ class S_Variant {
   PORTABLE_FUNCTION S_Variant(Choice &&choice)
       : s_opac_(std::forward<Choice>(choice)) {}
 
-  PORTABLE_FUNCTION
-  S_Variant() noexcept = default;
+  S_Variant() = default;
 
   template <
       typename Choice,

--- a/singularity-opac/neutrinos/neutrino_variant.hpp
+++ b/singularity-opac/neutrinos/neutrino_variant.hpp
@@ -44,7 +44,6 @@ class Variant {
   PORTABLE_FUNCTION Variant(Choice &&choice)
       : opac_(std::forward<Choice>(choice)) {}
 
-  PORTABLE_FUNCTION
   Variant() noexcept = default;
 
   template <

--- a/singularity-opac/photons/epbremsstrahlung_opacity_photons.hpp
+++ b/singularity-opac/photons/epbremsstrahlung_opacity_photons.hpp
@@ -177,8 +177,7 @@ class EPBremsstrahlungOpacity {
   Real mass_ion_;
   PlanckDistribution<pc> dist_;
   static constexpr Real mmw_ =
-      (pc::mp + pc::me) /
-      (2. * pc::mp); // Neutral fully ionized electron-proton gas
+      (pc::mp + pc::me) / 2.; // Neutral fully ionized electron-proton gas (g)
   static constexpr Real gff_ = 1.2;
   Real prefac_ = 8. * std::pow(pc::qe, 6) /
                  (3. * std::pow(pc::me * pc::c * pc::c, 2)) *

--- a/singularity-opac/photons/mean_photon_s_variant.hpp
+++ b/singularity-opac/photons/mean_photon_s_variant.hpp
@@ -42,8 +42,7 @@ class MeanSVariant {
   PORTABLE_FUNCTION MeanSVariant(Choice &&choice)
       : s_opac_(std::forward<Choice>(choice)) {}
 
-  PORTABLE_FUNCTION
-  MeanSVariant() noexcept = default;
+  MeanSVariant() = default;
 
   template <
       typename Choice,

--- a/singularity-opac/photons/mean_photon_variant.hpp
+++ b/singularity-opac/photons/mean_photon_variant.hpp
@@ -42,8 +42,7 @@ class MeanVariant {
   PORTABLE_FUNCTION MeanVariant(Choice &&choice)
       : opac_(std::forward<Choice>(choice)) {}
 
-  PORTABLE_FUNCTION
-  MeanVariant() noexcept = default;
+  MeanVariant() = default;
 
   template <
       typename Choice,

--- a/singularity-opac/photons/photon_s_variant.hpp
+++ b/singularity-opac/photons/photon_s_variant.hpp
@@ -44,8 +44,7 @@ class S_Variant {
   PORTABLE_FUNCTION S_Variant(Choice &&choice)
       : s_opac_(std::forward<Choice>(choice)) {}
 
-  PORTABLE_FUNCTION
-  S_Variant() noexcept = default;
+  S_Variant() = default;
 
   template <
       typename Choice,

--- a/singularity-opac/photons/photon_variant.hpp
+++ b/singularity-opac/photons/photon_variant.hpp
@@ -44,8 +44,7 @@ class Variant {
   PORTABLE_FUNCTION Variant(Choice &&choice)
       : opac_(std::forward<Choice>(choice)) {}
 
-  PORTABLE_FUNCTION
-  Variant() noexcept = default;
+  Variant() = default;
 
   template <
       typename Choice,


### PR DESCRIPTION
I wasn't able to properly create default versions of all the opacity variants due to some confusion probably due just to `noexcept`, but this PR also standardizes the lack of GPU decorators for default constructors. 