### PR TITLE
Fix incorrect n_e calculation

### DIFF
--- a/singularity-opac/photons/epbremsstrahlung_opacity_photons.hpp
+++ b/singularity-opac/photons/epbremsstrahlung_opacity_photons.hpp
@@ -84,7 +84,7 @@ class EPBremsstrahlungOpacity {
                             Real *lambda = nullptr) const {
     const Real thetaE = pc::kb * temp / (pc::me * pc::c * pc::c);
     const Real x = pc::h * nu / (pc::kb * temp);
-    const Real ne = rho / mmw_;
+    const Real ne = rho / mmw_ / 2.;
     const Real ni = ne;
     return prefac_ / std::sqrt(thetaE) * ne * ni * std::exp(-x) * gff_;
   }
@@ -120,7 +120,7 @@ class EPBremsstrahlungOpacity {
                   Real *lambda = nullptr) const {
 
     const Real thetaE = pc::kb * temp / (pc::me * pc::c * pc::c);
-    const Real ne = rho / mmw_;
+    const Real ne = rho / mmw_ / 2.;
     const Real ni = ne;
     return 4. * M_PI * pc::kb * temp / pc::h * prefac_ / std::sqrt(thetaE) *
            ne * ni * gff_;

--- a/singularity-opac/photons/thomson_s_opacity_photons.hpp
+++ b/singularity-opac/photons/thomson_s_opacity_photons.hpp
@@ -59,7 +59,8 @@ class ThomsonSOpacity {
   PORTABLE_INLINE_FUNCTION
   Real TotalScatteringCoefficient(const Real rho, const Real temp,
                                   const Real nu, Real *lambda = nullptr) const {
-    return (rho / apm_) * sigmaT_;
+    const Real ne = (rho / apm_) / 2.;
+    return ne * sigmaT_;
   }
 
  private:

--- a/test/test_thomson_s_opacities.cpp
+++ b/test/test_thomson_s_opacities.cpp
@@ -70,8 +70,8 @@ TEST_CASE("Thomson photon scattering opacities", "[ThomsonSPhotons]") {
           "calc s opacities", 0, 100, PORTABLE_LAMBDA(const int &i) {
             Real kappa = opac.TotalScatteringCoefficient(rho, temp, nu);
             Real sigma = opac.TotalCrossSection(rho, temp, nu);
-            if (FractionalDifference(kappa, rho / avg_particle_mass * sigma) >
-                EPS_TEST) {
+            if (FractionalDifference(kappa, (rho / avg_particle_mass) / 2 *
+                                                sigma) > EPS_TEST) {
               n_wrong_d() += 1;
             }
             if (FractionalDifference(sigma, sigmaT) > EPS_TEST) {


### PR DESCRIPTION
I was missing a factor of 2 in calculating electron number density in both Thomson and e-p bremss opacities. This PR fixes that. 

This PR exposes that even though we e.g. provide an average particle mass to scattering opacities, we are assuming fully ionized hydrogen. I think the solution going forward may be to allow e.g. `X`, `Y`, and `Z` parameters through the `Real *lambda` so opacities can calculate their own number densities and mean molecular weights when necessary. I'll make a note of this in the refactor issue.