### PR TITLE
Add unit-converted option to mean opacity variants

### DIFF
--- a/singularity-opac/neutrinos/mean_opacity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/mean_opacity_neutrinos.hpp
@@ -26,6 +26,7 @@
 #include <spiner/databox.hpp>
 
 #include <singularity-opac/neutrinos/mean_neutrino_variant.hpp>
+#include <singularity-opac/neutrinos/non_cgs_neutrinos.hpp>
 
 namespace singularity {
 namespace neutrinos {
@@ -220,7 +221,8 @@ class MeanOpacity {
 
 using MeanOpacityScaleFree = impl::MeanOpacity<PhysicalConstantsUnity>;
 using MeanOpacityCGS = impl::MeanOpacity<PhysicalConstantsCGS>;
-using MeanOpacity = impl::MeanVariant<MeanOpacityScaleFree, MeanOpacityCGS>;
+using MeanOpacity = impl::MeanVariant<MeanOpacityScaleFree, MeanOpacityCGS,
+                                      MeanNonCGSUnits<MeanOpacityCGS>>;
 
 } // namespace neutrinos
 } // namespace singularity

--- a/singularity-opac/neutrinos/mean_s_opacity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/mean_s_opacity_neutrinos.hpp
@@ -26,6 +26,7 @@
 #include <spiner/databox.hpp>
 
 #include <singularity-opac/neutrinos/mean_neutrino_s_variant.hpp>
+#include <singularity-opac/neutrinos/non_cgs_s_neutrinos.hpp>
 #include <singularity-opac/neutrinos/thermal_distributions_neutrinos.hpp>
 
 namespace singularity {
@@ -224,7 +225,8 @@ using MeanSOpacityScaleFree =
                        PhysicalConstantsUnity>;
 using MeanSOpacityCGS =
     impl::MeanSOpacity<FermiDiracDistributionNoMu<3>, PhysicalConstantsCGS>;
-using MeanSOpacity = impl::MeanSVariant<MeanSOpacityScaleFree, MeanSOpacityCGS>;
+using MeanSOpacity = impl::MeanSVariant<MeanSOpacityScaleFree, MeanSOpacityCGS,
+                                        MeanNonCGSUnitsS<MeanSOpacityCGS>>;
 
 } // namespace neutrinos
 } // namespace singularity

--- a/singularity-opac/photons/mean_opacity_photons.hpp
+++ b/singularity-opac/photons/mean_opacity_photons.hpp
@@ -196,7 +196,8 @@ class MeanOpacity {
 
 using MeanOpacityScaleFree = impl::MeanOpacity<PhysicalConstantsUnity>;
 using MeanOpacityCGS = impl::MeanOpacity<PhysicalConstantsCGS>;
-using MeanOpacity = impl::MeanVariant<MeanOpacityScaleFree, MeanOpacityCGS>;
+using MeanOpacity = impl::MeanVariant < MeanOpacityScaleFree, MeanOpacityCGS,
+      MeanNonCGSUnits<MeanOpacity<CGS>>;
 
 } // namespace photons
 } // namespace singularity

--- a/singularity-opac/photons/mean_opacity_photons.hpp
+++ b/singularity-opac/photons/mean_opacity_photons.hpp
@@ -26,6 +26,7 @@
 #include <spiner/databox.hpp>
 
 #include <singularity-opac/photons/mean_photon_variant.hpp>
+#include <singularity-opac/photons/non_cgs_photons.hpp>
 
 namespace singularity {
 namespace photons {

--- a/singularity-opac/photons/mean_opacity_photons.hpp
+++ b/singularity-opac/photons/mean_opacity_photons.hpp
@@ -197,8 +197,8 @@ class MeanOpacity {
 
 using MeanOpacityScaleFree = impl::MeanOpacity<PhysicalConstantsUnity>;
 using MeanOpacityCGS = impl::MeanOpacity<PhysicalConstantsCGS>;
-using MeanOpacity = impl::MeanVariant < MeanOpacityScaleFree, MeanOpacityCGS,
-      MeanNonCGSUnits<MeanOpacity<CGS>>;
+using MeanOpacity = impl::MeanVariant<MeanOpacityScaleFree, MeanOpacityCGS,
+                                      MeanNonCGSUnits<MeanOpacityCGS>>;
 
 } // namespace photons
 } // namespace singularity

--- a/singularity-opac/photons/mean_s_opacity_photons.hpp
+++ b/singularity-opac/photons/mean_s_opacity_photons.hpp
@@ -26,6 +26,7 @@
 #include <spiner/databox.hpp>
 
 #include <singularity-opac/photons/mean_photon_s_variant.hpp>
+#include <singularity-opac/photons/non_cgs_s_photons.hpp>
 #include <singularity-opac/photons/thermal_distributions_photons.hpp>
 
 namespace singularity {

--- a/singularity-opac/photons/mean_s_opacity_photons.hpp
+++ b/singularity-opac/photons/mean_s_opacity_photons.hpp
@@ -206,7 +206,8 @@ using MeanSOpacityScaleFree =
 using MeanSOpacityCGS =
     impl::MeanSOpacity<PlanckDistribution<PhysicalConstantsCGS>,
                        PhysicalConstantsCGS>;
-using MeanSOpacity = impl::MeanSVariant<MeanSOpacityScaleFree, MeanSOpacityCGS>;
+using MeanSOpacity = impl::MeanSVariant<MeanSOpacityScaleFree, MeanSOpacityCGS,
+                                        MeanNonCGSUnitsS<MeanSOpacityCGS>>;
 
 } // namespace photons
 } // namespace singularity


### PR DESCRIPTION
I was missing e.g. `MeanNonCGSUnits<MeanOpacityCGS>` in my `MeanOpacity` variants. This PR solves the issue of a code being able to use both unit-converted and scale-free mean opacities with a single type.