### PR TITLE
feat: add missing K2MeV_ conversion for neutrinos

### DIFF
--- a/singularity-opac/neutrinos/spiner_opac_neutrinos.hpp
+++ b/singularity-opac/neutrinos/spiner_opac_neutrinos.hpp
@@ -77,6 +77,8 @@ class SpinerOpacity {
                 Real lTMax, int NT, Real YeMin, Real YeMax, int NYe, Real leMin,
                 Real leMax, int Ne)
       : filename_("none"), memoryStatus_(impl::DataStatus::OnHost) {
+    lTMin += std::log10(K2MeV);
+    lTMax += std::log10(K2MeV);
     // Set metadata for lalphanu and ljnu
     lalphanu_.resize(NRho, NT, NYe, NEUTRINO_NTYPES, Ne);
     lalphanu_.setRange(0, leMin, leMax, Ne);
@@ -104,10 +106,10 @@ class SpinerOpacity {
           Real Ye = lalphanu_.range(2).x(iYe);
           for (int idx = 0; idx < NEUTRINO_NTYPES; ++idx) {
             RadiationType type = Idx2RadType(idx);
-            Real J = std::max(opac.Emissivity(rho, T, Ye, type), 0.0);
+            Real J = std::max(opac.Emissivity(rho, T * MeV2K, Ye, type), 0.0);
             Real lJ = toLog_(J);
             lJ_(iRho, iT, iYe, idx) = lJ;
-            Real JYe = std::max(opac.NumberEmissivity(rho, T, Ye, type), 0.0);
+            Real JYe = std::max(opac.NumberEmissivity(rho, T * MeV2K, Ye, type), 0.0);
             lJYe_(iRho, iT, iYe, idx) = toLog_(JYe);
             for (int ie = 0; ie < Ne; ++ie) {
               Real lE = lalphanu_.range(0).x(ie);
@@ -116,7 +118,7 @@ class SpinerOpacity {
               Real alpha = std::max(
                   opac.AbsorptionCoefficient(rho, T, Ye, type, nu), 0.0);
               lalphanu_(iRho, iT, iYe, idx, ie) = toLog_(alpha);
-              Real j = std::max(opac.EmissivityPerNuOmega(rho, T, Ye, type, nu),
+              Real j = std::max(opac.EmissivityPerNuOmega(rho, T * MeV2K, Ye, type, nu),
                                 0.0);
               ljnu_(iRho, iT, iYe, idx, ie) = toLog_(j);
             }

--- a/singularity-opac/neutrinos/spiner_opac_neutrinos.hpp
+++ b/singularity-opac/neutrinos/spiner_opac_neutrinos.hpp
@@ -64,6 +64,11 @@ class SpinerOpacity {
   static constexpr Real EPS = 10.0 * std::numeric_limits<Real>::min();
   static constexpr Real Hz2MeV = pc::h / (1e6 * pc::eV);
   static constexpr Real MeV2Hz = 1 / Hz2MeV;
+  static constexpr Real MeV2GK = 11.604525006;
+  static constexpr Real GK2MeV = 1. / MeV2GK;
+  static constexpr Real MeV2K = 1.e9 * MeV2GK;
+  static constexpr Real K2MeV = 1. / MeV2K;
+
 
   SpinerOpacity() = default;
 
@@ -360,11 +365,6 @@ class SpinerOpacity {
   }
 
  private:
-  static constexpr Real MeV2GK_ = 11.604525006;
-  static constexpr Real GK2MeV_ = 1. / MeV2GK_;
-  static constexpr Real MeV2K_ = 1.e9 * MeV2GK_;
-  static constexpr Real K2MeV_ = 1. / MeV2K_;
-
   // TODO(JMM): Offsets probably not necessary
   PORTABLE_INLINE_FUNCTION Real toLog_(const Real x, const Real offset) const {
     return std::log10(std::abs(std::max(x, -offset) + offset) + EPS);
@@ -383,7 +383,7 @@ class SpinerOpacity {
                                         RadiationType type, Real &lRho,
                                         Real &lT, int &idx) const {
     lRho = toLog_(rho);
-    lT = toLog_(temp * K2MeV_);
+    lT = toLog_(temp * K2MeV);
     idx = RadType2Idx(type);
   }
   const char *filename_;

--- a/singularity-opac/neutrinos/spiner_opac_neutrinos.hpp
+++ b/singularity-opac/neutrinos/spiner_opac_neutrinos.hpp
@@ -69,7 +69,6 @@ class SpinerOpacity {
   static constexpr Real MeV2K = 1.e9 * MeV2GK;
   static constexpr Real K2MeV = 1. / MeV2K;
 
-
   SpinerOpacity() = default;
 
   // Testing constructor that fills the tables with gray opacities

--- a/singularity-opac/neutrinos/spiner_opac_neutrinos.hpp
+++ b/singularity-opac/neutrinos/spiner_opac_neutrinos.hpp
@@ -360,6 +360,11 @@ class SpinerOpacity {
   }
 
  private:
+  static constexpr Real MeV2GK_ = 11.604525006;
+  static constexpr Real GK2MeV_ = 1. / MeV2GK_;
+  static constexpr Real MeV2K_ = 1.e9 * MeV2GK_;
+  static constexpr Real K2MeV_ = 1. / MeV2K_;
+
   // TODO(JMM): Offsets probably not necessary
   PORTABLE_INLINE_FUNCTION Real toLog_(const Real x, const Real offset) const {
     return std::log10(std::abs(std::max(x, -offset) + offset) + EPS);
@@ -378,7 +383,7 @@ class SpinerOpacity {
                                         RadiationType type, Real &lRho,
                                         Real &lT, int &idx) const {
     lRho = toLog_(rho);
-    lT = toLog_(temp);
+    lT = toLog_(temp * K2MeV_);
     idx = RadType2Idx(type);
   }
   const char *filename_;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,7 +17,7 @@ if(NOT Catch2_FOUND)
   FetchContent_Declare(
     Catch2
     GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-    GIT_TAG        v2.13.1)
+    GIT_TAG        v2.13.10)
   FetchContent_MakeAvailable(Catch2)
   list(APPEND CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/contrib)
 endif()


### PR DESCRIPTION
This PR adds `K2MeV_` in the spiner utils for neutrinos. Tables have temperature in MeV so we need to convert. 
One question: For the `ThermalDistribution` functions at the end, such as `EnergyDensityFromTemperature`, will I need to add the conversions there as well? I think those are the only temperatures not affected by my changes, but I am unsure if they are needed or not.