### PR TITLE
CMake updates

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,11 +15,13 @@ jobs:
         - name: Checkout code
           uses: actions/checkout@v2
           with:
-            submodules: true
+            submodules: recursive
         - name: Set system to non-interactive mode
           run: export DEBIAN_FRONTEND=noninteractive
         - name: install dependencies
-          run: sudo apt-get install -y --force-yes -qq build-essential libhdf5-serial-dev
+          run: |
+	    sudo apt-get update -y -qq
+	    sudo apt-get install -y --allow-downgrades --allow-remove-essential --allow-change-held-packages -qq build-essential libhdf5-serial-dev
         - name: build and run tests
           run: |
             mkdir -p bin

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,8 +20,8 @@ jobs:
           run: export DEBIAN_FRONTEND=noninteractive
         - name: install dependencies
           run: |
-	    sudo apt-get update -y -qq
-	    sudo apt-get install -y --allow-downgrades --allow-remove-essential --allow-change-held-packages -qq build-essential libhdf5-serial-dev
+            sudo apt-get update -y -qq
+            sudo apt-get install -y --allow-downgrades --allow-remove-essential --allow-change-held-packages -qq build-essential libhdf5-serial-dev
         - name: build and run tests
           run: |
             mkdir -p bin

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "utils/spiner"]
 	path = utils/spiner
   url = https://github.com/lanl/spiner.git
-[submodule "utils/ports-of-call"]
-	path = utils/ports-of-call
-	url = https://github.com/lanl/ports-of-call.git
 [submodule "utils/variant"]
 	path = utils/variant
 	url = https://github.com/mpark/variant.git
@@ -13,3 +10,6 @@
 [submodule "utils/kokkos"]
 	path = utils/kokkos
 	url = https://github.com/kokkos/kokkos.git
+[submodule "utils/ports-of-call"]
+	path = utils/ports-of-call
+	url = https://github.com/lanl/ports-of-call.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,9 @@
 [submodule "utils/spiner"]
 	path = utils/spiner
-	url = https://github.com/lanl/spiner.git
+  url = https://github.com/lanl/spiner.git
+[submodule "utils/ports-of-call"]
+	path = utils/ports-of-call
+	url = https://github.com/lanl/ports-of-call.git
 [submodule "utils/variant"]
 	path = utils/variant
 	url = https://github.com/mpark/variant.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,62 +1,63 @@
-# © 2021. Triad National Security, LLC. All rights reserved.  This
-# program was produced under U.S. Government contract
-# 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
-# is operated by Triad National Security, LLC for the U.S.  Department
-# of Energy/National Nuclear Security Administration. All rights in
-# the program are reserved by Triad National Security, LLC, and the
-# U.S. Department of Energy/National Nuclear Security
-# Administration. The Government is granted for itself and others
-# acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
-# license in this material to reproduce, prepare derivative works,
-# distribute copies to the public, perform publicly and display
-# publicly, and to permit others to do so.
+# © 2021. Triad National Security, LLC. All rights reserved.  This program was
+# produced under U.S. Government contract 89233218CNA000001 for Los Alamos
+# National Laboratory (LANL), which is operated by Triad National Security, LLC
+# for the U.S.  Department of Energy/National Nuclear Security Administration.
+# All rights in the program are reserved by Triad National Security, LLC, and
+# the U.S. Department of Energy/National Nuclear Security Administration. The
+# Government is granted for itself and others acting on its behalf a
+# nonexclusive, paid-up, irrevocable worldwide license in this material to
+# reproduce, prepare derivative works, distribute copies to the public, perform
+# publicly and display publicly, and to permit others to do so.
 
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.19)
 
-project("singularity-opac"
-      VERSION 0.0.1
-      DESCRIPTION
-        ""
-      HOMEPAGE_URL "https://github.com/lanl/singularity-opac/"
-)
+project(
+  "singularity-opac"
+  VERSION 0.0.1
+  DESCRIPTION ""
+  HOMEPAGE_URL "https://github.com/lanl/singularity-opac/")
 
 # Don't allow in-source builds
 file(TO_CMAKE_PATH "${PROJECT_BINARY_DIR}/CMakeLists.txt" LOC_PATH)
 if(EXISTS "${LOC_PATH}")
-  message(FATAL_ERROR
-    "You cannot build in a source directory (or any directory with a CMakeLists.txt file). "
-    "Please make a build subdirectory. Feel free to remove CMakeCache.txt and CMakeFiles.")
+  message(
+    FATAL_ERROR
+      "You cannot build in a source directory (or any directory with a CMakeLists.txt file). "
+      "Please make a build subdirectory. Feel free to remove CMakeCache.txt and CMakeFiles."
+  )
 endif()
 
 # If the user doesn't specify a build type, prefer RelWithDebInfo
 set(default_build_type "RelWithDebInfo")
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-  message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
-  set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
-    STRING "Choose the type of build." FORCE)
+  message(
+    STATUS
+      "Setting build type to '${default_build_type}' as none was specified.")
+  set(CMAKE_BUILD_TYPE
+      "${default_build_type}"
+      CACHE STRING "Choose the type of build." FORCE)
   # Set the possible values of build type for cmake-gui
-  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
-    "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release"
+                                               "MinSizeRel" "RelWithDebInfo")
 endif()
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 
-# simplier interface, but note it may make things more convoluted
-# as the project grows in size. For now, this is fine, but may
-# want to split flags if more source is added.
-add_library(${PROJECT_NAME} INTERFACE IMPORTED GLOBAL)
+# simplier interface, but note it may make things more convoluted as the project
+# grows in size. For now, this is fine, but may want to split flags if more
+# source is added.
+add_library(singularity-opac INTERFACE IMPORTED GLOBAL)
 # so we can use with add_subdirectory
-add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+add_library(singularity-opac::singularity-opac ALIAS singularity-opac)
 
-add_library (singularity-opac::flags INTERFACE IMPORTED GLOBAL)
-target_include_directories(singularity-opac::flags
-                           INTERFACE
-                           $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>)
+target_include_directories(
+  singularity-opac INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+                             $<INSTALL_INTERFACE:install/)
 
-include (SetupDeps)
-include (SetupOptions)
-include (SetupCompilers)
-include (SetupFlags)
+include(SetupDeps)
+include(SetupOptions)
+include(SetupCompilers)
+include(SetupFlags)
 
 include(GNUInstallDirs)
 include(CTest)
@@ -67,49 +68,22 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
   set(IS_TOPLEVEL_PROJECT TRUE)
 endif()
 
-
 set(CMAKE_EXPORT_COMPILE_COMMANDS On)
 
-# Patches variant to be compatible with cuda
-# Assumes "patch" is present on system
+# Patches variant to be compatible with cuda Assumes "patch" is present on
+# system
 message(STATUS "Patching mpark::variant to support GPUs")
-execute_process(COMMAND patch -N -s -V never
-                ${CMAKE_CURRENT_SOURCE_DIR}/utils/variant/include/mpark/variant.hpp
-                ${CMAKE_CURRENT_SOURCE_DIR}/utils/cuda_compatibility.patch)
-
-# xl fix
-target_compile_options(singularity-opac::flags INTERFACE
-                       $<$<COMPILE_LANG_AND_ID:CXX,XL>:-std=c++1y;-qxflag=disable__cplusplusOverride>)
-target_link_options(singularity-opac::flags INTERFACE
-                    $<$<COMPILE_LANG_AND_ID:CXX,XL>:-std=c++1y;-qxflag=disable__cplusplusOverride>)
-
-if(CMAKE_BUILD_TYPE STREQUAL "Release")
-  target_compile_options(singularity-opac::flags INTERFACE
-                         -use_fast_math)
-elseif(CMAKE_BUILD_TYPE STREQUAL "Debug" AND SINGULARITY_BETTER_DEBUG_FLAGS)
-  target_compile_options(
-    singularity-opac::flags
-    INTERFACE
-    "$<$<COMPILE_LANGUAGE:CXX>:-G;-lineinfo;>"
-    )
-endif()
+execute_process(
+  COMMAND
+    patch -N -s -V never
+    ${CMAKE_CURRENT_SOURCE_DIR}/utils/variant/include/mpark/variant.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/utils/cuda_compatibility.patch)
 
 # Invoke CMake scripts for setup
 if(SINGULARITY_INSTALL_LIBRARY)
-  include (SetupInstall)
+  include(SetupInstall)
 endif()
 
 if(SINGULARITY_BUILD_TESTS)
   add_subdirectory(test)
 endif()
-
-set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/LICENSE")
-
-include(CPack)
-
-include(FeatureSummary)
-feature_summary(WHAT ALL
-                INCLUDE_QUIET_PACKAGES
-                DESCRIPTION "Enabled Features:"
-                VAR enabledFeaturesText)
-message(STATUS "${enabledFeaturesText}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,13 +46,13 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 # simplier interface, but note it may make things more convoluted as the project
 # grows in size. For now, this is fine, but may want to split flags if more
 # source is added.
-add_library(singularity-opac INTERFACE IMPORTED GLOBAL)
+add_library(singularity-opac INTERFACE)
 # so we can use with add_subdirectory
 add_library(singularity-opac::singularity-opac ALIAS singularity-opac)
 
 target_include_directories(
-  singularity-opac INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
-                             $<INSTALL_INTERFACE:install/)
+  singularity-opac INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+                             $<INSTALL_INTERFACE:include>)
 
 include(SetupDeps)
 include(SetupOptions)

--- a/cmake/SetupDeps.cmake
+++ b/cmake/SetupDeps.cmake
@@ -25,7 +25,7 @@ if(NOT TARGET Kokkos::kokkos)
 else()
   message(status "Kokkos::kokkos provided by parent package")
 endif()
-target_link_libraries(singularigy-opac INTERFACE Kokkos::kokkos)
+target_link_libraries(singularity-opac INTERFACE Kokkos::kokkos)
 
 # =======================================
 # Find HDF5 - cmake@3.20+ provides HDF5::HDF5, but prior versions do not
@@ -41,7 +41,7 @@ find_package(
 if(HDF5_FOUND)
   target_compile_definitions(singularity-opac INTERFACE SPINER_USE_HDF)
   set_target_properties(
-    singularigy-opac
+    singularity-opac
     PROPERTIES INTERFACE_LINK_LIBRARIES "${HDF5_LIBRARIES};${HDF5_HL_LIBRARIES}"
                INTERFACE_COMPILE_DEFINITIONS
                "SINGULARITY_USE_HDF5;SPINER_USE_HDF"
@@ -65,7 +65,7 @@ if(HDF5_FOUND)
     else()
       message("MPI::MPI_CXX provided by parent package")
     endif()
-    target_link_libraries(singularigy-opac INTERFACE MPI::MPI_CXX)
+    target_link_libraries(singularity-opac INTERFACE MPI::MPI_CXX)
   endif()
 endif()
 

--- a/cmake/SetupDeps.cmake
+++ b/cmake/SetupDeps.cmake
@@ -1,76 +1,77 @@
 include(FeatureSummary)
-#=======================================
-# Setup CUDAToolkit
-# - provideds CUDA::toolkit
-#=======================================
-if (NOT TARGET CUDA::toolkit)
+# =======================================
+# Setup CUDAToolkit - provideds CUDA::toolkit
+# =======================================
+if(NOT TARGET CUDA::toolkit)
   find_package(CUDAToolkit QUIET)
 else()
   message(status "CUDA::toolkit provided by parent package")
 endif()
 
-#=======================================
-# Setup ports of call
-# - provides PortsofCall::PortsofCall
-#=======================================
-find_package(PortsofCall REQUIRED)
-target_link_libraries(singularity-opac::flags INTERFACE PortsofCall::PortsofCall)
+# =======================================
+# Setup ports of call - provides PortsofCall::PortsofCall
+# =======================================
+find_package(ports-of-call QUIET)
+if(NOT ports-of-call_FOUND)
+  add_subdirectory(utils/ports-of-call)
+endif()
+target_link_libraries(singularity-opac INTERFACE ports-of-call::ports-of-call)
 
-#=======================================
-# Setup Kokkos
-# - provides Kokkos::kokkos
-#=======================================
-if (NOT TARGET Kokkos::kokkos)
+# =======================================
+# Setup Kokkos - provides Kokkos::kokkos
+# =======================================
+if(NOT TARGET Kokkos::kokkos)
   find_package(Kokkos QUIET)
 else()
   message(status "Kokkos::kokkos provided by parent package")
 endif()
+target_link_libraries(singularigy-opac INTERFACE Kokkos::kokkos)
 
-#=======================================
-# Find HDF5
-# - cmake@3.20+ provides HDF5::HDF5, but
-#   prior versions do not
-#=======================================
-# Can't play the target games above unless using
-# cmake 3.20+, so leave this one for now.
-find_package(HDF5 COMPONENTS C HL QUIET)
+# =======================================
+# Find HDF5 - cmake@3.20+ provides HDF5::HDF5, but prior versions do not
+# =======================================
+# Can't play the target games above unless using cmake 3.20+, so leave this one
+# for now.
+find_package(
+  HDF5
+  COMPONENTS C HL
+  QUIET)
 
-# findpackage doesnt export an interface for HDF5,
-# so create one
-if (HDF5_FOUND)
-    target_compile_definitions(singularity-opac::flags INTERFACE SPINER_USE_HDF)
-    add_library(${PROJECT_NAME}::hdf5 INTERFACE IMPORTED)
-    set_target_properties(${PROJECT_NAME}::hdf5
-    PROPERTIES
-        INTERFACE_LINK_LIBRARIES "${HDF5_LIBRARIES};${HDF5_HL_LIBRARIES}"
-        INTERFACE_COMPILE_DEFINITIONS "SINGULARITY_USE_HDF5;SPINER_USE_HDF"
-        INTERFACE_INCLUDE_DIRECTORIES "${HDF5_INCLUDE_DIRS}"
-    )
+# findpackage doesnt export an interface for HDF5, so create one
+if(HDF5_FOUND)
+  target_compile_definitions(singularity-opac INTERFACE SPINER_USE_HDF)
+  set_target_properties(
+    singularigy-opac
+    PROPERTIES INTERFACE_LINK_LIBRARIES "${HDF5_LIBRARIES};${HDF5_HL_LIBRARIES}"
+               INTERFACE_COMPILE_DEFINITIONS
+               "SINGULARITY_USE_HDF5;SPINER_USE_HDF"
+               INTERFACE_INCLUDE_DIRECTORIES "${HDF5_INCLUDE_DIRS}")
 
-    # if HDF5 is parallel, also get MPI libraries
-    if (HDF5_IS_PARALLEL)
-      message(status "Parallel HDF5 found. Looking for MPI")
-      # Provides MPI::MPI_CXX
-      if (NOT TARGET MPI::MPI_CXX)
-	find_package(MPI COMPONENTS)# CXX REQUIRED)
-	if (NOT MPI_FOUND)
-	  message(FATAL_ERROR
-	    "HDF5 parallel found, but could not find MPI! "
-	    "Try specifying a path to an MPI directory or MPI compiler "
-	    " via -DMPI_HOME=/path or -DMPI_CXX_COMPILER=/path, "
-	    "or set CMAKE_PREFIX_PATH to your preferred HDF5 directory "
-	    "via -DCMAKE_PREFIX_PATH=/path.")
-	endif()
-      else()
-	message("MPI::MPI_CXX provided by parent package")
+  # if HDF5 is parallel, also get MPI libraries
+  if(HDF5_IS_PARALLEL)
+    message(status "Parallel HDF5 found. Looking for MPI")
+    # Provides MPI::MPI_CXX
+    if(NOT TARGET MPI::MPI_CXX)
+      find_package(MPI COMPONENTS) # CXX REQUIRED)
+      if(NOT MPI_FOUND)
+        message(
+          FATAL_ERROR
+            "HDF5 parallel found, but could not find MPI! "
+            "Try specifying a path to an MPI directory or MPI compiler "
+            " via -DMPI_HOME=/path or -DMPI_CXX_COMPILER=/path, "
+            "or set CMAKE_PREFIX_PATH to your preferred HDF5 directory "
+            "via -DCMAKE_PREFIX_PATH=/path.")
       endif()
+    else()
+      message("MPI::MPI_CXX provided by parent package")
     endif()
+    target_link_libraries(singularigy-opac INTERFACE MPI::MPI_CXX)
+  endif()
 endif()
 
-#=======================================
-# Setup Catch2
-# - provides Catch2::Catch2
-#=======================================
-if (NOT TARGET Catch2::Catch2)
+# =======================================
+# Setup Catch2 - provides Catch2::Catch2
+# =======================================
+if(NOT TARGET Catch2::Catch2)
   find_package(Catch2 QUIET)
 endif()

--- a/cmake/SetupFlags.cmake
+++ b/cmake/SetupFlags.cmake
@@ -20,14 +20,11 @@ target_compile_options(
 target_link_options(singularity-opac INTERFACE $<${cxx_xl}:
                     "-std=c++1y;-qxflag=disable__cplusplusOverride" >)
 
-# Base Include directories
-target_include_directories(
-  singularity-opac
-  INTERFACE $<${without_kokkos}:
-            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/utils/herumi-fmath>
-            >
-            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/utils>
-            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>)
+# Base Include directories target_include_directories( singularity-opac
+# INTERFACE $<${without_kokkos}:
+# $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/utils/herumi-fmath> >
+# $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/utils>
+# $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>)
 
 target_compile_options(
   singularity-opac

--- a/cmake/SetupFlags.cmake
+++ b/cmake/SetupFlags.cmake
@@ -1,6 +1,3 @@
-
-
-
 # Easier generator expressions
 set(build_debug "$<CONFIG:Debug>")
 set(build_release "$<CONFIG:Release>")
@@ -17,74 +14,52 @@ set(hide_more_warn "$<BOOL:${SINGULARITY_HIDE_MORE_WARNINGS}>")
 set(better_debug "$<BOOL:${SINGULARITY_BETTER_DEBUG_FLAGS}>")
 
 # xl fix
-target_compile_options(${PROJECT_NAME} INTERFACE
-                        $<${cxx_xl}:
-                            "-std=c++1y;-qxflag=disable__cplusplusOverride"
-                        >
-)
-target_link_options(${PROJECT_NAME} INTERFACE
-                        $<${cxx_xl}:
-                            "-std=c++1y;-qxflag=disable__cplusplusOverride"
-                        >
-)
+target_compile_options(
+  singularity-opac INTERFACE $<${cxx_xl}:
+                             "-std=c++1y;-qxflag=disable__cplusplusOverride" >)
+target_link_options(singularity-opac INTERFACE $<${cxx_xl}:
+                    "-std=c++1y;-qxflag=disable__cplusplusOverride" >)
 
 # Base Include directories
-target_include_directories(${PROJECT_NAME}
-  INTERFACE
-    $<${without_kokkos}:
-      $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/utils/herumi-fmath>
-    >
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/utils>
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+target_include_directories(
+  singularity-opac
+  INTERFACE $<${without_kokkos}:
+            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/utils/herumi-fmath>
+            >
+            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/utils>
+            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>)
 
-)
-
-target_compile_options(${PROJECT_NAME}
-INTERFACE
-    $<${with_kokkos}:
-        $<${with_cuda}:
+target_compile_options(
+  singularity-opac
+  INTERFACE $<${with_kokkos}:
+            $<${with_cuda}:
             $<${cxx_lang}:
-                "--expt-relaxed-constexpr"
-                $<${hide_more_warn}:
-                    "-Xcudafe;--diag_suppress=esa_on_defaulted_function_ignored"
-                > #hide_more_warn
+            "--expt-relaxed-constexpr"
+            $<${hide_more_warn}:
+            "-Xcudafe;--diag_suppress=esa_on_defaulted_function_ignored"
+            > # hide_more_warn
             > # cxx_lang
             $<${build_release}:
-                "-use_fast_math"
+            "-use_fast_math"
             > # build_release
             $<${build_debug}:
-                $<${better_debug}:
-                    $<${cxx_lang}:
-                        "-G;-lineinfo"
-                    > # cxx_lang
-                > # better_debug
+            $<${better_debug}:
+            $<${cxx_lang}:
+            "-G;-lineinfo"
+            > # cxx_lang
+            > # better_debug
             > # build_debug
-        > # with_cuda
-    > # with_kokkos
+            > # with_cuda
+            > # with_kokkos
 )
 
-target_compile_definitions(${PROJECT_NAME}
-INTERFACE
-  $<${with_kokkos}:
-    PORTABILITY_STRATEGY_KOKKOS
-  >
-  $<${without_kokkos}:
-    $<${with_fmath}:
-      SINGULARITY_USE_FMATH
-    >
-  >
-)
-
-# target_link_libraries brings in compile flags, compile defs, link flags.
-target_link_libraries(${PROJECT_NAME}
-INTERFACE
-    $<${with_kokkos}:
-        Kokkos::kokkos
-    >
-    $<${with_hdf5}:
-        ${PROJECT_NAME}::hdf5
-        $<${with_mpi}:
-            MPI::MPI_CXX
-        >
-    >
-)
+target_compile_definitions(
+  singularity-opac
+  INTERFACE $<${with_kokkos}:
+            PORTABILITY_STRATEGY_KOKKOS
+            >
+            $<${without_kokkos}:
+            $<${with_fmath}:
+            SINGULARITY_USE_FMATH
+            >
+            >)

--- a/singularity-opac/base/fast-math/logs.hpp
+++ b/singularity-opac/base/fast-math/logs.hpp
@@ -1,0 +1,153 @@
+//======================================================================
+// © 2021-2023. Triad National Security, LLC. All rights reserved.  This
+// program was produced under U.S. Government contract 89233218CNA000001
+// for Los Alamos National Laboratory (LANL), which is operated by Triad
+// National Security, LLC for the U.S.  Department of Energy/National
+// Nuclear Security Administration. All rights in the program are
+// reserved by Triad National Security, LLC, and the U.S. Department of
+// Energy/National Nuclear Security Administration. The Government is
+// granted for itself and others acting on its behalf a nonexclusive,
+// paid-up, irrevocable worldwide license in this material to reproduce,
+// prepare derivative works, distribute copies to the public, perform
+// publicly and display publicly, and to permit others to do so.
+//======================================================================
+
+#ifndef _SINGULARITY_EOS_UTILS_FAST_MATH_LOGS_
+#define _SINGULARITY_EOS_UTILS_FAST_MATH_LOGS_
+#include <cassert>
+#include <cmath>
+#include <ports-of-call/portability.hpp>
+
+/*
+ * These functions are for use when moving to and from the gridding space
+ * for Spiner grids.
+ *
+ * The core idea here is to move onto a grid that's roughly
+ * logarithmically spaced. It doesn't actually matter if that grid is
+ * EXACTLY logarithmic. Just that it is approximately so.
+ * There are however some constraints that do matter:
+ *
+ * 1. The function we use to translate to "grid space" must be
+ * precise, meaning you get the same answer each time.
+ *
+ * 2. The function must be invertible, meaning you can go back to
+ * "linear space." Ideally it is also continuous.
+ *
+ * 3. The function and its inverse must be fast.
+ *
+ * To meet these constraints, we approximate a logarithm by using
+ * frexp and ldexp to split a real number into its mantissa + exponent
+ * in base 2. The mantissa is a real number on the interval [0.5, 1)
+ * and the exponent is an integer such that
+ *
+ * mantissa * 2^exponent = number
+ *
+ * To truly take the log, one needs to take the log of the mantissa.
+ * However, the first term in the logarithm's Taylor series is linear.
+ * Thus a linear approximation to log, for small numbers is valid.
+ * We use that linear approximation, which turns out to be:
+ *
+ * 2*(mantissa - 1)
+ *
+ * So that mantissa = 0.5 returns log_2(0.5) = -1 and mantissa (1)
+ * yields 0.
+ *
+ * Then the approximate log of the whole thing is the approximation of
+ * the log of the mantissa, plus the exponent:
+ *
+ * 2*(mantissa - 1) + exponent
+ *
+ * Which is a continuous, invertible function that approximates lg
+ * only relatively accurately. The absolute difference of this
+ * function from lg is about 0.1 at its largest. This translates to a
+ * relative difference of at most 25%.
+ *
+ * However, we don't mind this difference, as we're only interested in
+ * generating a grid spacing "close enough" to log spacing. As long as
+ * we can go into and out of "grid space" reliably and quickly, we're
+ * happy, and this function is an EXACT map into and out of that
+ * space.
+ */
+
+namespace singularity {
+namespace FastMath {
+
+PORTABLE_FORCEINLINE_FUNCTION
+double fastlg(const double x) {
+  int n;
+  assert(x > 0 && "log divergent for x <= 0");
+#ifndef SINGULARITY_USE_SINGLE_LOGS
+  // double precision is default
+  const double y = frexp(x, &n);
+#else
+  // faster but less accurate
+  const float y = frexpf((float)x, &n);
+#endif // SINGULARITY_USE_SINGLE_LOGS
+  return 2 * (y - 1) + n;
+}
+
+PORTABLE_FORCEINLINE_FUNCTION
+double fastpow2(const double x) {
+
+  const int flr = std::floor(x);
+  const double remainder = x - flr;
+  const double mantissa = 0.5 * (remainder + 1);
+  const double exponent = flr + 1;
+#ifndef SINGULARITY_USE_SINGLE_LOGS
+  // double precision is default
+  return ldexp(mantissa, exponent);
+#else
+  // Faster but less accurate
+  return ldexpf((float)mantissa, exponent);
+#endif // SINGULARITY_USE_SINGLE_LOGS
+}
+
+PORTABLE_FORCEINLINE_FUNCTION
+double lg(const double x) {
+
+  assert(x > 0 && "log divergent for x <= 0");
+
+#ifndef SINGULARITY_USE_TRUE_LOG_GRIDDING
+  // Default expression
+  return fastlg(x);
+#else
+#ifndef SINGULARITY_USE_SINGLE_LOGS
+  // double precision is default
+  return std::log2(x);
+#else
+  return std::log2f(x);
+#endif // SINGULARITY_USE_SINGLE_LOGS
+#endif // SINGULARITY_USE_TRUE_LOG_GRIDDING
+}
+
+PORTABLE_FORCEINLINE_FUNCTION
+double pow2(const double x) {
+#ifndef SINGULARITY_USE_TRUE_LOG_GRIDDING
+  // Default expression
+  return fastpow2(x);
+#else
+#ifndef SINGULARITY_USE_SINGLE_LOGS
+  // double precision is default
+  return std::exp2(x);
+#else
+  return std::exp2f(x);
+#endif // SINGULARITY_USE_SINGLE_LOGS
+#endif // SINGULARITY_USE_TRUE_LOG_GRIDDING
+}
+
+PORTABLE_FORCEINLINE_FUNCTION
+double log10(const double x) {
+  constexpr double LOG2OLOG10 = 0.301029995663981195;
+  return LOG2OLOG10 * lg(x);
+}
+
+PORTABLE_FORCEINLINE_FUNCTION
+double pow10(const double x) {
+  constexpr double LOG10OLOG2 = 3.321928094887362626;
+  return pow2(LOG10OLOG2 * x);
+}
+
+} // namespace FastMath
+} // namespace singularity
+
+#endif //  _SINGULARITY_EOS_UTILS_FAST_MATH_LOGS_

--- a/singularity-opac/base/indexers.hpp
+++ b/singularity-opac/base/indexers.hpp
@@ -16,9 +16,9 @@
 #ifndef SINGULARITY_OPAC_BASE_INDEXERS_
 #define SINGULARITY_OPAC_BASE_INDEXERS_
 
-#include <fast-math/logs.hpp>
+#include "fast-math/logs.hpp"
 #include <spiner/databox.hpp>
-#include <variant/include/mpark/variant.hpp>
+// #include <variant/include/mpark/variant.hpp>
 
 #include <singularity-opac/chebyshev/chebyshev.hpp>
 
@@ -30,6 +30,8 @@
 
 namespace singularity {
 namespace indexers {
+
+using DataBox = Spiner::DataBox<Real>;
 
 template <typename T>
 struct Identity {
@@ -58,8 +60,8 @@ class Linear {
     SetRange_(numin, numax, N);
   }
 
-  PORTABLE_INLINE_FUNCTION Linear(const Spiner::DataBox &data, Real numin,
-                                  Real numax, int N)
+  PORTABLE_INLINE_FUNCTION Linear(const DataBox &data, Real numin, Real numax,
+                                  int N)
       : data_(data) {
     SetRange_(numin, numax, N);
   }
@@ -79,7 +81,7 @@ class Linear {
   void SetRange_(Real numin, Real numax, int N) {
     data_.setRange(0, numin, numax, N);
   }
-  Spiner::DataBox data_;
+  DataBox data_;
 };
 
 class LogLinear {
@@ -97,8 +99,7 @@ class LogLinear {
   }
 
   PORTABLE_INLINE_FUNCTION
-  LogLinear(const Spiner::DataBox &data, Real numin, Real numax, int N)
-      : data_(data) {
+  LogLinear(const DataBox &data, Real numin, Real numax, int N) : data_(data) {
     SetRange_(numin, numax, N);
   }
 
@@ -111,15 +112,15 @@ class LogLinear {
 
   PORTABLE_INLINE_FUNCTION
   Real operator()(const Real nu) {
-    return data_.interpToReal(BDMath::log10(nu));
+    return data_.interpToReal(FastMath::log10(nu));
   }
 
  private:
   PORTABLE_INLINE_FUNCTION
   void SetRange_(Real numin, Real numax, int N) {
-    data_.setRange(0, BDMath::log10(numin), BDMath::log10(numax), N);
+    data_.setRange(0, FastMath::log10(numin), FastMath::log10(numax), N);
   }
-  Spiner::DataBox data_;
+  DataBox data_;
 };
 
 template <int N, typename Data_t>
@@ -129,8 +130,8 @@ class LogCheb {
   PORTABLE_INLINE_FUNCTION
   LogCheb(Data_t data, Data_t logdata, Data_t coeffs, Real numin, Real numax)
       : data_(data), logdata_(logdata), coeffs_(coeffs), numin_(numin),
-        numax_(numax), lnumin_(BDMath::log10(numin)),
-        lnumax_(BDMath::log10(numax)) {}
+        numax_(numax), lnumin_(FastMath::log10(numin)),
+        lnumax_(FastMath::log10(numax)) {}
 
   PORTABLE_INLINE_FUNCTION
   Real &operator[](const int i) { return data_[i]; }
@@ -140,14 +141,14 @@ class LogCheb {
   template <typename Vandermonde_t>
   PORTABLE_INLINE_FUNCTION void SetInterpCoeffs(const Vandermonde_t &v) {
     for (int i = 0; i < N; ++i) {
-      logdata_[i] = BDMath::log10(std::abs(data_[i]) + 1e-20);
+      logdata_[i] = FastMath::log10(std::abs(data_[i]) + 1e-20);
     }
     chebyshev::MatMultiply(v, logdata_, coeffs_, N);
   }
 
   PORTABLE_INLINE_FUNCTION
   Real operator()(const Real nu) {
-    Real lnu = BDMath::log10(nu);
+    Real lnu = FastMath::log10(nu);
     return std::pow(
         10, chebyshev::InterpFromCoeffs(lnu, lnumin_, lnumax_, coeffs_, N));
   }

--- a/singularity-opac/neutrinos/mean_neutrino_s_variant.hpp
+++ b/singularity-opac/neutrinos/mean_neutrino_s_variant.hpp
@@ -18,11 +18,11 @@
 
 #include <utility>
 
+#include <mpark/variant.hpp>
 #include <ports-of-call/portability.hpp>
 #include <singularity-opac/base/opac_error.hpp>
 #include <singularity-opac/base/radiation_types.hpp>
 #include <singularity-opac/neutrinos/neutrino_s_variant.hpp>
-#include <variant/include/mpark/variant.hpp>
 
 namespace singularity {
 namespace neutrinos {

--- a/singularity-opac/neutrinos/mean_neutrino_variant.hpp
+++ b/singularity-opac/neutrinos/mean_neutrino_variant.hpp
@@ -18,11 +18,11 @@
 
 #include <utility>
 
+#include <mpark/variant.hpp>
 #include <ports-of-call/portability.hpp>
 #include <singularity-opac/base/opac_error.hpp>
 #include <singularity-opac/base/radiation_types.hpp>
 #include <singularity-opac/neutrinos/neutrino_variant.hpp>
-#include <variant/include/mpark/variant.hpp>
 
 namespace singularity {
 namespace neutrinos {

--- a/singularity-opac/neutrinos/mean_opacity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/mean_opacity_neutrinos.hpp
@@ -30,6 +30,8 @@
 
 namespace singularity {
 namespace neutrinos {
+
+using DataBox = Spiner::DataBox<Real>;
 namespace impl {
 
 #define EPS (10.0 * std::numeric_limits<Real>::min())
@@ -210,8 +212,8 @@ class MeanOpacity {
   PORTABLE_INLINE_FUNCTION Real fromLog_(const Real lx) const {
     return std::pow(10., lx);
   }
-  Spiner::DataBox lkappaPlanck_;
-  Spiner::DataBox lkappaRosseland_;
+  DataBox lkappaPlanck_;
+  DataBox lkappaRosseland_;
   const char *filename_;
 };
 

--- a/singularity-opac/neutrinos/mean_s_opacity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/mean_s_opacity_neutrinos.hpp
@@ -31,6 +31,7 @@
 
 namespace singularity {
 namespace neutrinos {
+using DataBox = Spiner::DataBox<Real>;
 namespace impl {
 
 #define EPS (10.0 * std::numeric_limits<Real>::min())
@@ -211,8 +212,8 @@ class MeanSOpacity {
   PORTABLE_INLINE_FUNCTION Real fromLog_(const Real lx) const {
     return std::pow(10., lx);
   }
-  Spiner::DataBox lkappaPlanck_;
-  Spiner::DataBox lkappaRosseland_;
+  DataBox lkappaPlanck_;
+  DataBox lkappaRosseland_;
   const char *filename_;
 };
 

--- a/singularity-opac/neutrinos/neutrino_s_variant.hpp
+++ b/singularity-opac/neutrinos/neutrino_s_variant.hpp
@@ -18,10 +18,10 @@
 
 #include <utility>
 
+#include <mpark/variant.hpp>
 #include <ports-of-call/portability.hpp>
 #include <singularity-opac/base/opac_error.hpp>
 #include <singularity-opac/base/radiation_types.hpp>
-#include <variant/include/mpark/variant.hpp>
 
 namespace singularity {
 namespace neutrinos {

--- a/singularity-opac/neutrinos/neutrino_variant.hpp
+++ b/singularity-opac/neutrinos/neutrino_variant.hpp
@@ -18,10 +18,10 @@
 
 #include <utility>
 
+#include <mpark/variant.hpp>
 #include <ports-of-call/portability.hpp>
 #include <singularity-opac/base/opac_error.hpp>
 #include <singularity-opac/base/radiation_types.hpp>
-#include <variant/include/mpark/variant.hpp>
 
 namespace singularity {
 namespace neutrinos {

--- a/singularity-opac/neutrinos/opac_neutrinos.hpp
+++ b/singularity-opac/neutrinos/opac_neutrinos.hpp
@@ -16,7 +16,7 @@
 #ifndef SINGULARITY_OPAC_NEUTRINOS_OPAC_NEUTRINOS_
 #define SINGULARITY_OPAC_NEUTRINOS_OPAC_NEUTRINOS_
 
-#include <variant/include/mpark/variant.hpp>
+#include <mpark/variant.hpp>
 
 #include <singularity-opac/neutrinos/brt_neutrinos.hpp>
 #include <singularity-opac/neutrinos/gray_opacity_neutrinos.hpp>

--- a/singularity-opac/neutrinos/s_opac_neutrinos.hpp
+++ b/singularity-opac/neutrinos/s_opac_neutrinos.hpp
@@ -16,7 +16,7 @@
 #ifndef SINGULARITY_OPAC_NEUTRINOS_S_OPAC_NEUTRINOS_
 #define SINGULARITY_OPAC_NEUTRINOS_S_OPAC_NEUTRINOS_
 
-#include <variant/include/mpark/variant.hpp>
+#include <mpark/variant.hpp>
 
 #include <singularity-opac/neutrinos/gray_s_opacity_neutrinos.hpp>
 #include <singularity-opac/neutrinos/neutrino_s_variant.hpp>

--- a/singularity-opac/neutrinos/spiner_opac_neutrinos.hpp
+++ b/singularity-opac/neutrinos/spiner_opac_neutrinos.hpp
@@ -21,12 +21,12 @@
 #include <cstdio>
 #include <string>
 
-#include <fast-math/logs.hpp>
 #include <ports-of-call/portability.hpp>
 #include <spiner/databox.hpp>
 #include <spiner/interpolation.hpp>
 #include <spiner/spiner_types.hpp>
 
+#include <singularity-opac/base/fast-math/logs.hpp>
 #include <singularity-opac/base/opac_error.hpp>
 #include <singularity-opac/base/radiation_types.hpp>
 #include <singularity-opac/base/sp5.hpp>
@@ -49,6 +49,8 @@
 
 namespace singularity {
 namespace neutrinos {
+
+using DataBox = Spiner::DataBox<Real>;
 
 namespace impl {
 enum class DataStatus { Deallocated, OnDevice, OnHost };
@@ -109,7 +111,8 @@ class SpinerOpacity {
             Real J = std::max(opac.Emissivity(rho, T * MeV2K, Ye, type), 0.0);
             Real lJ = toLog_(J);
             lJ_(iRho, iT, iYe, idx) = lJ;
-            Real JYe = std::max(opac.NumberEmissivity(rho, T * MeV2K, Ye, type), 0.0);
+            Real JYe =
+                std::max(opac.NumberEmissivity(rho, T * MeV2K, Ye, type), 0.0);
             lJYe_(iRho, iT, iYe, idx) = toLog_(JYe);
             for (int ie = 0; ie < Ne; ++ie) {
               Real lE = lalphanu_.range(0).x(ie);
@@ -118,8 +121,8 @@ class SpinerOpacity {
               Real alpha = std::max(
                   opac.AbsorptionCoefficient(rho, T, Ye, type, nu), 0.0);
               lalphanu_(iRho, iT, iYe, idx, ie) = toLog_(alpha);
-              Real j = std::max(opac.EmissivityPerNuOmega(rho, T * MeV2K, Ye, type, nu),
-                                0.0);
+              Real j = std::max(
+                  opac.EmissivityPerNuOmega(rho, T * MeV2K, Ye, type, nu), 0.0);
               ljnu_(iRho, iT, iYe, idx, ie) = toLog_(j);
             }
           }
@@ -130,8 +133,8 @@ class SpinerOpacity {
 
   // DataBox constructor. Note that this constructor *shallow* copies
   // the databoxes, so they must be managed externally.
-  SpinerOpacity(const Spiner::DataBox &lalphanu, const Spiner::DataBox ljnu,
-                const Spiner::DataBox lJ, const Spiner::DataBox lJYe)
+  SpinerOpacity(const DataBox &lalphanu, const DataBox ljnu, const DataBox lJ,
+                const DataBox lJYe)
       : memoryStatus_(impl::DataStatus::OnHost), lalphanu_(lalphanu),
         ljnu_(ljnu), lJ_(lJ), lJYe_(lJYe) {}
 
@@ -391,7 +394,7 @@ class SpinerOpacity {
   impl::DataStatus memoryStatus_ = impl::DataStatus::Deallocated;
   // TODO(JMM): Integrating J and JYe seems wise.
   // We can add more things here as needed.
-  Spiner::DataBox lalphanu_, ljnu_, lJ_, lJYe_;
+  DataBox lalphanu_, ljnu_, lJ_, lJYe_;
   // TODO(JMM): Should we add table bounds? Given they're recorded in
   // each spiner table, I lean towards no, but could be convinced
   // otherwise if we need to do extrapolation, etc.

--- a/singularity-opac/photons/mean_opacity_photons.hpp
+++ b/singularity-opac/photons/mean_opacity_photons.hpp
@@ -30,6 +30,8 @@
 
 namespace singularity {
 namespace photons {
+
+using DataBox = Spiner::DataBox<Real>;
 namespace impl {
 
 #define EPS (10.0 * std::numeric_limits<Real>::min())
@@ -186,8 +188,8 @@ class MeanOpacity {
   PORTABLE_INLINE_FUNCTION Real fromLog_(const Real lx) const {
     return std::pow(10., lx);
   }
-  Spiner::DataBox lkappaPlanck_;
-  Spiner::DataBox lkappaRosseland_;
+  DataBox lkappaPlanck_;
+  DataBox lkappaRosseland_;
   const char *filename_;
 };
 

--- a/singularity-opac/photons/mean_photon_s_variant.hpp
+++ b/singularity-opac/photons/mean_photon_s_variant.hpp
@@ -18,11 +18,11 @@
 
 #include <utility>
 
+#include <mpark/variant.hpp>
 #include <ports-of-call/portability.hpp>
 #include <singularity-opac/base/opac_error.hpp>
 #include <singularity-opac/base/radiation_types.hpp>
 #include <singularity-opac/photons/photon_s_variant.hpp>
-#include <variant/include/mpark/variant.hpp>
 
 namespace singularity {
 namespace photons {

--- a/singularity-opac/photons/mean_photon_variant.hpp
+++ b/singularity-opac/photons/mean_photon_variant.hpp
@@ -18,11 +18,11 @@
 
 #include <utility>
 
+#include <mpark/variant.hpp>
 #include <ports-of-call/portability.hpp>
 #include <singularity-opac/base/opac_error.hpp>
 #include <singularity-opac/base/radiation_types.hpp>
 #include <singularity-opac/photons/photon_variant.hpp>
-#include <variant/include/mpark/variant.hpp>
 
 namespace singularity {
 namespace photons {

--- a/singularity-opac/photons/mean_s_opacity_photons.hpp
+++ b/singularity-opac/photons/mean_s_opacity_photons.hpp
@@ -31,6 +31,7 @@
 
 namespace singularity {
 namespace photons {
+using DataBox = Spiner::DataBox<Real>;
 namespace impl {
 
 #define EPS (10.0 * std::numeric_limits<Real>::min())
@@ -192,8 +193,8 @@ class MeanSOpacity {
   PORTABLE_INLINE_FUNCTION Real fromLog_(const Real lx) const {
     return std::pow(10., lx);
   }
-  Spiner::DataBox lkappaPlanck_;
-  Spiner::DataBox lkappaRosseland_;
+  DataBox lkappaPlanck_;
+  DataBox lkappaRosseland_;
   const char *filename_;
 };
 

--- a/singularity-opac/photons/photon_s_variant.hpp
+++ b/singularity-opac/photons/photon_s_variant.hpp
@@ -18,10 +18,10 @@
 
 #include <utility>
 
+#include <mpark/variant.hpp>
 #include <ports-of-call/portability.hpp>
 #include <singularity-opac/base/opac_error.hpp>
 #include <singularity-opac/base/radiation_types.hpp>
-#include <variant/include/mpark/variant.hpp>
 
 namespace singularity {
 namespace photons {

--- a/singularity-opac/photons/photon_variant.hpp
+++ b/singularity-opac/photons/photon_variant.hpp
@@ -18,10 +18,10 @@
 
 #include <utility>
 
+#include <mpark/variant.hpp>
 #include <ports-of-call/portability.hpp>
 #include <singularity-opac/base/opac_error.hpp>
 #include <singularity-opac/base/radiation_types.hpp>
-#include <variant/include/mpark/variant.hpp>
 
 namespace singularity {
 namespace photons {

--- a/singularity-opac/photons/s_opac_photons.hpp
+++ b/singularity-opac/photons/s_opac_photons.hpp
@@ -16,7 +16,7 @@
 #ifndef SINGULARITY_OPAC_PHOTONS_S_OPAC_PHOTONS_
 #define SINGULARITY_OPAC_PHOTONS_S_OPAC_PHOTONS_
 
-#include <variant/include/mpark/variant.hpp>
+#include <mpark/variant.hpp>
 
 #include <singularity-opac/photons/gray_s_opacity_photons.hpp>
 #include <singularity-opac/photons/non_cgs_s_photons.hpp>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,63 +1,58 @@
-# © 2021. Triad National Security, LLC. All rights reserved.  This
-# program was produced under U.S. Government contract 89233218CNA000001
-# for Los Alamos National Laboratory (LANL), which is operated by Triad
-# National Security, LLC for the U.S.  Department of Energy/National
-# Nuclear Security Administration. All rights in the program are
-# reserved by Triad National Security, LLC, and the U.S. Department of
-# Energy/National Nuclear Security Administration. The Government is
-# granted for itself and others acting on its behalf a nonexclusive,
-# paid-up, irrevocable worldwide license in this material to reproduce,
-# prepare derivative works, distribute copies to the public, perform
+# © 2021. Triad National Security, LLC. All rights reserved.  This program was
+# produced under U.S. Government contract 89233218CNA000001 for Los Alamos
+# National Laboratory (LANL), which is operated by Triad National Security, LLC
+# for the U.S.  Department of Energy/National Nuclear Security Administration.
+# All rights in the program are reserved by Triad National Security, LLC, and
+# the U.S. Department of Energy/National Nuclear Security Administration. The
+# Government is granted for itself and others acting on its behalf a
+# nonexclusive, paid-up, irrevocable worldwide license in this material to
+# reproduce, prepare derivative works, distribute copies to the public, perform
 # publicly and display publicly, and to permit others to do so.
 
 if(NOT Catch2_FOUND)
   # Get catch2
   message(STATUS "Fetching Catch2 as needed")
-  Include(FetchContent)
+  include(FetchContent)
   FetchContent_Declare(
     Catch2
     GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-    GIT_TAG        v2.13.10)
+    GIT_TAG v2.13.10)
   FetchContent_MakeAvailable(Catch2)
   list(APPEND CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/contrib)
 endif()
 
 # Build tests
 message(STATUS "Configuring unit tests")
-#find_package(${PROJECT_NAME} CONFIG REQUIRED)
 
-add_library(catch2_define)
-target_sources(catch2_define PUBLIC catch2_define.cpp)
-target_link_libraries(catch2_define PUBLIC
-                      Catch2::Catch2)
+# add_library(catch2_define) target_sources(catch2_define PUBLIC
+# catch2_define.cpp) target_link_libraries(catch2_define PUBLIC Catch2::Catch2)
 
-add_executable(${PROJECT_NAME}_unit_tests)
-target_sources(${PROJECT_NAME}_unit_tests
-PRIVATE
-  test_thermal_dist.cpp
-  test_scalefree_opacities.cpp
-  test_gray_opacities.cpp
-  test_epbremsstrahlung_opacities.cpp
-  test_gray_s_opacities.cpp
-  test_brt_opacities.cpp
-  test_thomson_s_opacities.cpp
-  test_chebyshev.cpp
-  test_spiner_opac_neutrinos.cpp
-  test_mean_opacities.cpp
-  test_variant.cpp
-)
+add_executable(singularity-opac_unit_tests)
+target_sources(
+  singularity-opac_unit_tests
+  PRIVATE catch2_define.cpp
+          test_thermal_dist.cpp
+          test_scalefree_opacities.cpp
+          test_gray_opacities.cpp
+          test_epbremsstrahlung_opacities.cpp
+          test_gray_s_opacities.cpp
+          test_brt_opacities.cpp
+          test_thomson_s_opacities.cpp
+          test_chebyshev.cpp
+          test_spiner_opac_neutrinos.cpp
+          test_mean_opacities.cpp
+          test_variant.cpp)
 
-target_link_libraries(${PROJECT_NAME}_unit_tests
-PRIVATE
-  catch2_define
-  ${PROJECT_NAME})
+target_link_libraries(singularity-opac_unit_tests
+                      PRIVATE Catch2::Catch2 singularity-opac::singularity-opac)
 
 # Ensure code works with C++11 and earlier
 # TODO(MM): Remove this later when it's not needed.
-set_target_properties(${PROJECT_NAME}_unit_tests
+set_target_properties(
+  singularity-opac_unit_tests
   PROPERTIES CXX_STANDARD 14
-  CXX_STANDARD_REQUIRED YES
-  CXX_EXTENSIONS NO)
+             CXX_STANDARD_REQUIRED YES
+             CXX_EXTENSIONS NO)
 
 include(Catch)
-catch_discover_tests(${PROJECT_NAME}_unit_tests)
+catch_discover_tests(singularity-opac_unit_tests)

--- a/test/catch2_define.cpp
+++ b/test/catch2_define.cpp
@@ -13,7 +13,7 @@
 // publicly, and to permit others to do so.
 // ======================================================================
 
-#include "../utils/ports-of-call/portability.hpp"
+#include "ports-of-call/portability.hpp"
 
 #define CATCH_CONFIG_RUNNER
 #include <catch2/catch.hpp>

--- a/test/test_brt_opacities.cpp
+++ b/test/test_brt_opacities.cpp
@@ -32,7 +32,7 @@
 using namespace singularity;
 
 using pc = PhysicalConstantsCGS;
-
+using DataBox = Spiner::DataBox<Real>;
 #ifdef PORTABILITY_STRATEGY_KOKKOS
 using atomic_view = Kokkos::MemoryTraits<Kokkos::Atomic>;
 #endif
@@ -169,7 +169,7 @@ TEST_CASE("BRT neutrino opacities", "[BRTNeutrinos]") {
                                                     nu_coeffs, nu_min, nu_max);
             opac.EmissivityPerNu(rho, temp, Ye, type, nu_bins, J_cheb, nbins);
             Real Jtrue = opac.EmissivityPerNu(rho, temp, Ye, type, nu);
-            J_cheb.SetInterpCoeffs(Spiner::DataBox(vm9, 9, 9));
+            J_cheb.SetInterpCoeffs(DataBox(vm9, 9, 9));
             if (std::isnan(J_cheb(nu)) ||
                 ((std::abs(Jtrue) >= 1e-14 || J_cheb(nu) >= 1e-14) &&
                  FractionalDifference(J_cheb(nu), Jtrue) > EPS_TEST)) {

--- a/test/test_chebyshev.cpp
+++ b/test/test_chebyshev.cpp
@@ -17,12 +17,13 @@
 
 #include <catch2/catch.hpp>
 
-#include <spiner/databox.hpp>
 #include <ports-of-call/portability.hpp>
 #include <ports-of-call/portable_arrays.hpp>
 #include <singularity-opac/chebyshev/chebyshev.hpp>
+#include <spiner/databox.hpp>
 using namespace singularity::chebyshev;
 
+using DataBox = Spiner::DataBox<Real>;
 #ifdef PORTABILITY_STRATEGY_KOKKOS
 using atomic_view = Kokkos::MemoryTraits<Kokkos::Atomic>;
 #endif
@@ -45,8 +46,8 @@ TEST_CASE("Chebyshev Polynomials", "[Chebyshev]") {
     constexpr Real mu = (xmax + xmin) / 2;
     constexpr Real sigma = 1;
     Real *x = (Real *)PORTABLE_MALLOC(sizeof(Real) * N);
-    Real *vm9 = (Real*)PORTABLE_MALLOC(9 * 9 * sizeof(Real));
-      
+    Real *vm9 = (Real *)PORTABLE_MALLOC(9 * 9 * sizeof(Real));
+
     portableFor(
         "Set vm", 0, 1, PORTABLE_LAMBDA(const int &i) { get_vmbox(vm9); });
 
@@ -62,7 +63,7 @@ TEST_CASE("Chebyshev Polynomials", "[Chebyshev]") {
         Real *ycoeffs = (Real *)PORTABLE_MALLOC(sizeof(Real) * N);
         portableFor(
             "Compute Cheb polynomial", 0, 1, PORTABLE_LAMBDA(const int &i) {
-              MatMultiply(Spiner::DataBox(vm9, 9, 9), y, ycoeffs, N);
+              MatMultiply(DataBox(vm9, 9, 9), y, ycoeffs, N);
             });
         AND_THEN("The chebyshev polynomials fit") {
           int n_wrong_h = 0;

--- a/test/test_epbremsstrahlung_opacities.cpp
+++ b/test/test_epbremsstrahlung_opacities.cpp
@@ -31,7 +31,7 @@
 using namespace singularity;
 
 using pc = PhysicalConstantsCGS;
-
+using DataBox = Spiner::DataBox<Real>;
 #ifdef PORTABILITY_STRATEGY_KOKKOS
 using atomic_view = Kokkos::MemoryTraits<Kokkos::Atomic>;
 #endif
@@ -132,8 +132,7 @@ TEST_CASE("E-P bremsstrahlung photon opacities", "[EPBremsstrahlungPhotons]") {
 
       Real *nu_bins = (Real *)PORTABLE_MALLOC(nbins * sizeof(Real));
       Real *temp_bins = (Real *)PORTABLE_MALLOC(ntemps * sizeof(Real));
-      Spiner::DataBox loglin_bins(Spiner::AllocationTarget::Device, ntemps,
-                                  nbins);
+      DataBox loglin_bins(Spiner::AllocationTarget::Device, ntemps, nbins);
 
       portableFor(
           "set nu bins", 0, nbins, PORTABLE_LAMBDA(const int &i) {

--- a/test/test_gray_opacities.cpp
+++ b/test/test_gray_opacities.cpp
@@ -37,6 +37,8 @@ using pc = PhysicalConstantsCGS;
 using atomic_view = Kokkos::MemoryTraits<Kokkos::Atomic>;
 #endif
 
+using DataBox = Spiner::DataBox<Real>;
+
 template <typename T>
 PORTABLE_INLINE_FUNCTION T FractionalDifference(const T &a, const T &b) {
   return 2 * std::abs(b - a) / (std::abs(a) + std::abs(b) + 1e-20);
@@ -167,7 +169,7 @@ TEST_CASE("Gray neutrino opacities", "[GrayNeutrinos]") {
                                                     nu_coeffs, nu_min, nu_max);
             opac.EmissivityPerNu(rho, temp, Ye, type, nu_bins, J_cheb, nbins);
             Real Jtrue = opac.EmissivityPerNu(rho, temp, Ye, type, nu);
-            J_cheb.SetInterpCoeffs(Spiner::DataBox(vm9, 9, 9));
+            J_cheb.SetInterpCoeffs(DataBox(vm9, 9, 9));
             if (std::isnan(J_cheb(nu)) ||
                 ((std::abs(Jtrue) >= 1e-14 || J_cheb(nu) >= 1e-14) &&
                  FractionalDifference(J_cheb(nu), Jtrue) > EPS_TEST)) {
@@ -282,8 +284,7 @@ TEST_CASE("Gray photon opacities", "[GrayPhotons]") {
 
       Real *nu_bins = (Real *)PORTABLE_MALLOC(nbins * sizeof(Real));
       Real *temp_bins = (Real *)PORTABLE_MALLOC(ntemps * sizeof(Real));
-      Spiner::DataBox loglin_bins(Spiner::AllocationTarget::Device, ntemps,
-                                  nbins);
+      DataBox loglin_bins(Spiner::AllocationTarget::Device, ntemps, nbins);
 
       portableFor(
           "set nu bins", 0, nbins, PORTABLE_LAMBDA(const int &i) {

--- a/test/test_mean_opacities.cpp
+++ b/test/test_mean_opacities.cpp
@@ -72,11 +72,11 @@ TEST_CASE("Mean neutrino opacities", "[MeanNeutrinos]") {
     constexpr Real nu = 1.25 * MeV2Hz; // 1 MeV
 
     constexpr int nT = 10;
-    constexpr Real lRhoMin = std::log10(0.1 * rho);
-    constexpr Real lRhoMax = std::log10(10. * rho);
+    const Real lRhoMin = std::log10(0.1 * rho);
+    const Real lRhoMax = std::log10(10. * rho);
     constexpr int NRho = 2;
-    constexpr Real lTMin = std::log10(0.1 * temp);
-    constexpr Real lTMax = std::log10(10. * temp);
+    const Real lTMin = std::log10(0.1 * temp);
+    const Real lTMax = std::log10(10. * temp);
     constexpr int NT = 10;
     constexpr Real YeMin = 0.1;
     constexpr Real YeMax = 0.5;
@@ -234,11 +234,12 @@ TEST_CASE("Mean neutrino scattering opacities", "[MeanNeutrinosS]") {
     constexpr Real nu = 1.25 * MeV2Hz; // 1 MeV
 
     constexpr int nT = 10;
-    constexpr Real lRhoMin = std::log10(0.1 * rho);
-    constexpr Real lRhoMax = std::log10(10. * rho);
+    // please stop copy-pasting code
+    const Real lRhoMin = std::log10(0.1 * rho);
+    const Real lRhoMax = std::log10(10. * rho);
     constexpr int NRho = 2;
-    constexpr Real lTMin = std::log10(0.1 * temp);
-    constexpr Real lTMax = std::log10(10. * temp);
+    const Real lTMin = std::log10(0.1 * temp);
+    const Real lTMax = std::log10(10. * temp);
     constexpr int NT = 10;
     constexpr Real YeMin = 0.1;
     constexpr Real YeMax = 0.5;
@@ -402,11 +403,11 @@ TEST_CASE("Mean photon opacities", "[MeanPhotons]") {
     constexpr Real nu = 1.e15;  // Hz
 
     constexpr int nT = 10;
-    constexpr Real lRhoMin = std::log10(0.1 * rho);
-    constexpr Real lRhoMax = std::log10(10. * rho);
+    const Real lRhoMin = std::log10(0.1 * rho);
+    const Real lRhoMax = std::log10(10. * rho);
     constexpr int NRho = 2;
-    constexpr Real lTMin = std::log10(0.1 * temp);
-    constexpr Real lTMax = std::log10(10. * temp);
+    const Real lTMin = std::log10(0.1 * temp);
+    const Real lTMax = std::log10(10. * temp);
     constexpr int NT = 10;
 
     constexpr Real kappa = 1.e-20;
@@ -552,11 +553,11 @@ TEST_CASE("Mean photon scattering opacities", "[MeanPhotonS]") {
     constexpr Real nu = 1.e15;  // Hz
 
     constexpr int nT = 10;
-    constexpr Real lRhoMin = std::log10(0.1 * rho);
-    constexpr Real lRhoMax = std::log10(10. * rho);
+    const Real lRhoMin = std::log10(0.1 * rho);
+    const Real lRhoMax = std::log10(10. * rho);
     constexpr int NRho = 2;
-    constexpr Real lTMin = std::log10(0.1 * temp);
-    constexpr Real lTMax = std::log10(10. * temp);
+    const Real lTMin = std::log10(0.1 * temp);
+    const Real lTMax = std::log10(10. * temp);
     constexpr int NT = 10;
 
     constexpr Real sigma = 1.e-20;
@@ -611,7 +612,8 @@ TEST_CASE("Mean photon scattering opacities", "[MeanPhotonS]") {
         int n_wrong = 0;
         portableReduce(
             "rebuilt table vs gray", 0, NRho, 0, NT, 0, 0,
-            PORTABLE_LAMBDA(const int iRho, const int iT, const int igarbage, int &accumulate) {
+            PORTABLE_LAMBDA(const int iRho, const int iT, const int igarbage,
+                            int &accumulate) {
               const Real lRho =
                   lRhoMin + (lRhoMax - lRhoMin) / (NRho - 1) * iRho;
               const Real rho = std::pow(10, lRho);

--- a/test/test_spiner_opac_neutrinos.cpp
+++ b/test/test_spiner_opac_neutrinos.cpp
@@ -60,8 +60,8 @@ TEST_CASE("Spiner opacities, filled with gray data",
   constexpr Real lRhoMin = 8;
   constexpr Real lRhoMax = 12;
   constexpr int NRho = 32;
-  constexpr Real lTMin = -2 + std::log10(MeV2K);
-  constexpr Real lTMax = 2 + std::log10(MeV2K);
+  const Real lTMin = -2 + std::log10(MeV2K);
+  const Real lTMax = 2 + std::log10(MeV2K);
   constexpr int NT = 32;
   constexpr Real YeMin = 0.1;
   constexpr Real YeMax = 0.5;
@@ -73,7 +73,7 @@ TEST_CASE("Spiner opacities, filled with gray data",
   const std::string grayname = "gray.sp5";
 
   WHEN("We initialize a gray neutrino opacity and tabulate it") {
-    using Grid_t = Spiner::RegularGrid1D;
+    using Grid_t = Spiner::RegularGrid1D<Real>;
 
     // Offset the frequencies to hopefully get over the point
     // where the power laws transition

--- a/test/test_thermal_dist.cpp
+++ b/test/test_thermal_dist.cpp
@@ -32,6 +32,7 @@
 using namespace singularity;
 
 using pc = PhysicalConstantsCGS;
+using DataBox = Spiner::DataBox<Real>;
 
 #ifdef PORTABILITY_STRATEGY_KOKKOS
 using atomic_view = Kokkos::MemoryTraits<Kokkos::Atomic>;

--- a/utils/ports-of-call
+++ b/utils/ports-of-call
@@ -1,1 +1,0 @@
-spiner/ports-of-call/


### PR DESCRIPTION
Lots has changed in how we build, so I've made some fixes. This isn't a complete redo of the build, which we should do but this shouldn't be too much work.

- Removed `::flags` and `::hdf5` flags
- explicit target names `singularity-opac`
- CMake formatting
- `ports-of-call` submodule update (do we need `spiner` for this project?)

