### PR TITLE
SetupDeps before SetupOptions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,8 +53,8 @@ target_include_directories(singularity-opac::flags
                            INTERFACE
                            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>)
 
-include (SetupOptions)
 include (SetupDeps)
+include (SetupOptions)
 include (SetupCompilers)
 include (SetupFlags)
 

--- a/cmake/SetupDeps.cmake
+++ b/cmake/SetupDeps.cmake
@@ -1,4 +1,5 @@
 include(FeatureSummary)
+include(CMakeDependentOption)
 #=======================================
 # Setup CUDAToolkit
 # - provideds CUDA::toolkit


### PR DESCRIPTION
This PR reverts a recent change so that `SetupDeps` precedes `SetupOptions` in `CMakeLists`. This change was made in #47 but it's breaking GPU compilation for me (the code finds `CUDAToolkit` in `SetupDeps` and checks for `CUDA::toolkit` in `SetupOptions`. @Yurlungur I'm not sure why this change was made, is it safe to revert?