### PR TITLE
Use https for ports of call submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,4 +12,4 @@
 	url = https://github.com/kokkos/kokkos.git
 [submodule "utils/ports-of-call"]
 	path = utils/ports-of-call
-	url = git@github.com:lanl/ports-of-call.git
+	url = https://github.com/lanl/ports-of-call.git


### PR DESCRIPTION
The `ports-of-call` submodule was listed in `.gitmodules` as using ssh instead of https. It has been changed to https.