### PR TITLE
Return physical constants object from opacities

### DIFF
--- a/singularity-opac/constants/constants.hpp
+++ b/singularity-opac/constants/constants.hpp
@@ -194,6 +194,45 @@ struct PhysicalConstants {
   static constexpr Real gA = axial_vector_coupling_constant;
 };
 
+struct RuntimePhysicalConstants {
+  template <typename T>
+  RuntimePhysicalConstants(T pc)
+      : na(pc.na), alpha(pc.alpha), h(pc.h), hbar(pc.hbar), kb(pc.kb),
+        r_gas(pc.r_gas), qe(pc.qe), c(pc.c), g_newt(pc.g_newt),
+        g_accel(pc.g_accel), me(pc.me), mp(pc.mp), mn(pc.mn), amu(pc.amu),
+        sb(pc.sb), ar(pc.ar), faraday(pc.faraday), mu0(pc.mu0), eps0(pc.eps0),
+        eV(pc.eV), Fc(pc.Fc), nu_sigma0(pc.nu_sigma0), gA(pc.gA) {}
+
+  const Real na;
+  const Real alpha;
+  const Real h;
+  const Real hbar;
+  const Real kb;
+  const Real r_gas;
+  const Real qe;
+  const Real c;
+  const Real g_newt;
+  const Real g_accel;
+  const Real me;
+  const Real mp;
+  const Real mn;
+  const Real amu;
+  const Real sb;
+  const Real ar;
+  const Real faraday;
+  const Real mu0;
+  const Real eps0;
+  const Real eV;
+  const Real Fc;
+  const Real nu_sigma0;
+  const Real gA;
+};
+
+template <typename T>
+RuntimePhysicalConstants GetRuntimePhysicalConstants(T phys_constants) {
+  return RuntimePhysicalConstants(phys_constants);
+}
+
 using PhysicalConstantsUnity =
     PhysicalConstants<BaseUnity, UnitConversionDefault>;
 using PhysicalConstantsSI =

--- a/singularity-opac/constants/constants.hpp
+++ b/singularity-opac/constants/constants.hpp
@@ -1,5 +1,5 @@
 // ======================================================================
-// © 2021. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2024. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract
 // 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
 // is operated by Triad National Security, LLC for the U.S.

--- a/singularity-opac/neutrinos/brt_neutrinos.hpp
+++ b/singularity-opac/neutrinos/brt_neutrinos.hpp
@@ -32,6 +32,8 @@ namespace neutrinos {
 template <typename ThermalDistribution, typename pc = PhysicalConstantsCGS>
 class BRTOpacity {
  public:
+  using PC = pc;
+
   BRTOpacity() = default;
   BRTOpacity(const ThermalDistribution &dist) : dist_(dist) {}
   BRTOpacity GetOnDevice() { return *this; }

--- a/singularity-opac/neutrinos/brt_neutrinos.hpp
+++ b/singularity-opac/neutrinos/brt_neutrinos.hpp
@@ -44,7 +44,6 @@ class BRTOpacity {
   void PrintParams() const noexcept {
     printf("Burrows-Reddy-Thompson analytic neutrino opacity.\n");
   }
-
   inline void Finalize() noexcept {}
 
   PORTABLE_INLINE_FUNCTION

--- a/singularity-opac/neutrinos/brt_neutrinos.hpp
+++ b/singularity-opac/neutrinos/brt_neutrinos.hpp
@@ -1,5 +1,5 @@
 // ======================================================================
-// © 2021. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2024. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract
 // 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
 // is operated by Triad National Security, LLC for the U.S.

--- a/singularity-opac/neutrinos/brt_neutrinos.hpp
+++ b/singularity-opac/neutrinos/brt_neutrinos.hpp
@@ -42,6 +42,10 @@ class BRTOpacity {
   void PrintParams() const noexcept {
     printf("Burrows-Reddy-Thompson analytic neutrino opacity.\n");
   }
+
+  PORTABLE_INLINE_FUNCTION
+  pc GetPhysicalConstants() const { return pc(); }
+
   inline void Finalize() noexcept {}
 
   PORTABLE_INLINE_FUNCTION

--- a/singularity-opac/neutrinos/brt_neutrinos.hpp
+++ b/singularity-opac/neutrinos/brt_neutrinos.hpp
@@ -45,9 +45,6 @@ class BRTOpacity {
     printf("Burrows-Reddy-Thompson analytic neutrino opacity.\n");
   }
 
-  PORTABLE_INLINE_FUNCTION
-  pc GetPhysicalConstants() const { return pc(); }
-
   inline void Finalize() noexcept {}
 
   PORTABLE_INLINE_FUNCTION

--- a/singularity-opac/neutrinos/gray_opacity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/gray_opacity_neutrinos.hpp
@@ -44,7 +44,6 @@ class GrayOpacity {
   void PrintParams() const noexcept {
     printf("Gray opacity. kappa = %g\n", kappa_);
   }
-
   inline void Finalize() noexcept {}
 
   PORTABLE_INLINE_FUNCTION
@@ -175,9 +174,6 @@ class GrayOpacity {
                                     Real *lambda = nullptr) const {
     return dist_.NumberDensityFromTemperature(temp, type, lambda);
   }
-
-  // PORTABLE_INLINE_FUNCTION
-  // pc GetPhysicalConstants() const { return pc(); }
 
  private:
   Real kappa_; // Opacity. Units of cm^2/g

--- a/singularity-opac/neutrinos/gray_opacity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/gray_opacity_neutrinos.hpp
@@ -173,6 +173,9 @@ class GrayOpacity {
     return dist_.NumberDensityFromTemperature(temp, type, lambda);
   }
 
+  PORTABLE_INLINE_FUNCTION
+  pc GetPhysicalConstants() const { return pc(); }
+
  private:
   Real kappa_; // Opacity. Units of cm^2/g
   ThermalDistribution dist_;

--- a/singularity-opac/neutrinos/gray_opacity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/gray_opacity_neutrinos.hpp
@@ -1,5 +1,5 @@
 // ======================================================================
-// © 2021. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2024. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract
 // 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
 // is operated by Triad National Security, LLC for the U.S.

--- a/singularity-opac/neutrinos/gray_opacity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/gray_opacity_neutrinos.hpp
@@ -45,11 +45,6 @@ class GrayOpacity {
     printf("Gray opacity. kappa = %g\n", kappa_);
   }
 
-  PORTABLE_INLINE_FUNCTION
-  RuntimePhysicalConstants GetPhysicalConstants() const {
-    return GetRuntimePhysicalConstants(pc());
-  }
-
   inline void Finalize() noexcept {}
 
   PORTABLE_INLINE_FUNCTION

--- a/singularity-opac/neutrinos/gray_opacity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/gray_opacity_neutrinos.hpp
@@ -30,6 +30,8 @@ namespace neutrinos {
 template <typename ThermalDistribution, typename pc = PhysicalConstantsCGS>
 class GrayOpacity {
  public:
+  using PC = pc;
+
   GrayOpacity() = default;
   GrayOpacity(const Real kappa) : kappa_(kappa) {}
   GrayOpacity(const ThermalDistribution &dist, const Real kappa)
@@ -42,6 +44,12 @@ class GrayOpacity {
   void PrintParams() const noexcept {
     printf("Gray opacity. kappa = %g\n", kappa_);
   }
+
+  PORTABLE_INLINE_FUNCTION
+  RuntimePhysicalConstants GetPhysicalConstants() const {
+    return GetRuntimePhysicalConstants(pc());
+  }
+
   inline void Finalize() noexcept {}
 
   PORTABLE_INLINE_FUNCTION
@@ -173,8 +181,8 @@ class GrayOpacity {
     return dist_.NumberDensityFromTemperature(temp, type, lambda);
   }
 
-  PORTABLE_INLINE_FUNCTION
-  pc GetPhysicalConstants() const { return pc(); }
+  // PORTABLE_INLINE_FUNCTION
+  // pc GetPhysicalConstants() const { return pc(); }
 
  private:
   Real kappa_; // Opacity. Units of cm^2/g

--- a/singularity-opac/neutrinos/mean_neutrino_variant.hpp
+++ b/singularity-opac/neutrinos/mean_neutrino_variant.hpp
@@ -1,5 +1,5 @@
 // ======================================================================
-// © 2021. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2024. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract
 // 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
 // is operated by Triad National Security, LLC for the U.S.
@@ -101,6 +101,12 @@ class MeanVariant {
   inline void Finalize() noexcept {
     return mpark::visit([](auto &opac) { return opac.Finalize(); }, opac_);
   }
+
+#ifdef SPINER_USE_HDF
+  void Save(const std::string &filename) const {
+    return mpark::visit([=](auto &opac) { return opac.Save(filename); }, opac_);
+  }
+#endif
 };
 
 } // namespace impl

--- a/singularity-opac/neutrinos/mean_neutrino_variant.hpp
+++ b/singularity-opac/neutrinos/mean_neutrino_variant.hpp
@@ -28,7 +28,7 @@ namespace singularity {
 namespace neutrinos {
 namespace impl {
 
-template <typename... Opacs>
+template <typename CONSTANTS, typename... Opacs>
 class MeanVariant {
  private:
   opac_variant<Opacs...> opac_;
@@ -87,6 +87,16 @@ class MeanVariant {
         },
         opac_);
   }
+
+  PORTABLE_INLINE_FUNCTION CONSTANTS GetPhysicalConstants() const {
+    return mpark::visit([](auto &opac) { return opac.GetPhysicalConstants(); },
+                        opac_);
+  }
+  // static CONSTANTS GetPhysicalConstants() {
+  //  return mpark::visit(
+  //      [](auto &opac) { return decltype(opac)::GetPhysicalConstants(); },
+  //     opac_);
+  // }
 
   inline void Finalize() noexcept {
     return mpark::visit([](auto &opac) { return opac.Finalize(); }, opac_);

--- a/singularity-opac/neutrinos/mean_neutrino_variant.hpp
+++ b/singularity-opac/neutrinos/mean_neutrino_variant.hpp
@@ -28,7 +28,7 @@ namespace singularity {
 namespace neutrinos {
 namespace impl {
 
-template <typename PC, typename... Opacs>
+template <typename... Opacs>
 class MeanVariant {
  private:
   opac_variant<Opacs...> opac_;
@@ -69,6 +69,16 @@ class MeanVariant {
         opac_);
   }
 
+  PORTABLE_INLINE_FUNCTION RuntimePhysicalConstants
+  GetRuntimePhysicalConstants() const {
+    return mpark::visit(
+        [=](const auto &opac) {
+          using PC = typename std::decay_t<decltype(opac)>::PC;
+          return singularity::GetRuntimePhysicalConstants(PC());
+        },
+        opac_);
+  }
+
   PORTABLE_INLINE_FUNCTION Real PlanckMeanAbsorptionCoefficient(
       const Real rho, const Real temp, const Real Ye,
       const RadiationType type) const {
@@ -86,11 +96,6 @@ class MeanVariant {
           return opac.RosselandMeanAbsorptionCoefficient(rho, temp, Ye, type);
         },
         opac_);
-  }
-
-  PORTABLE_INLINE_FUNCTION PC GetPhysicalConstants() const {
-    return mpark::visit([](auto &opac) { return opac.GetPhysicalConstants(); },
-                        opac_);
   }
 
   inline void Finalize() noexcept {

--- a/singularity-opac/neutrinos/mean_neutrino_variant.hpp
+++ b/singularity-opac/neutrinos/mean_neutrino_variant.hpp
@@ -28,7 +28,7 @@ namespace singularity {
 namespace neutrinos {
 namespace impl {
 
-template <typename CONSTANTS, typename... Opacs>
+template <typename PC, typename... Opacs>
 class MeanVariant {
  private:
   opac_variant<Opacs...> opac_;
@@ -88,15 +88,10 @@ class MeanVariant {
         opac_);
   }
 
-  PORTABLE_INLINE_FUNCTION CONSTANTS GetPhysicalConstants() const {
+  PORTABLE_INLINE_FUNCTION PC GetPhysicalConstants() const {
     return mpark::visit([](auto &opac) { return opac.GetPhysicalConstants(); },
                         opac_);
   }
-  // static CONSTANTS GetPhysicalConstants() {
-  //  return mpark::visit(
-  //      [](auto &opac) { return decltype(opac)::GetPhysicalConstants(); },
-  //     opac_);
-  // }
 
   inline void Finalize() noexcept {
     return mpark::visit([](auto &opac) { return opac.Finalize(); }, opac_);

--- a/singularity-opac/neutrinos/mean_opacity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/mean_opacity_neutrinos.hpp
@@ -104,7 +104,6 @@ class MeanOpacity {
 
   PORTABLE_INLINE_FUNCTION
   pc GetPhysicalConstants() const { return pc(); }
-  // static pc GetPhysicalConstants() { return pc(); }
 
   void Finalize() {
     lkappaPlanck_.finalize();

--- a/singularity-opac/neutrinos/mean_opacity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/mean_opacity_neutrinos.hpp
@@ -1,5 +1,5 @@
 // ======================================================================
-// © 2022. Triad National Security, LLC. All rights reserved.  This
+// © 2022-2024. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract
 // 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
 // is operated by Triad National Security, LLC for the U.S.
@@ -37,12 +37,9 @@ namespace impl {
 // TODO(BRR) Note: It is assumed that lambda is constant for all densities,
 // temperatures, and Ye
 
-template <typename pc = PhysicalConstantsCGS>
 class MeanOpacity {
 
  public:
-  using PC = pc;
-
   MeanOpacity() = default;
   template <typename Opacity>
   MeanOpacity(const Opacity &opac, const Real lRhoMin, const Real lRhoMax,
@@ -136,8 +133,7 @@ class MeanOpacity {
                         const Real lTMax, const int NT, const Real YeMin,
                         const Real YeMax, const int NYe, Real lNuMin,
                         Real lNuMax, const int NNu, Real *lambda = nullptr) {
-    static_assert(std::is_same<PC, typename Opacity::PC>::value,
-                  "Mean opacity constants must match opacity constants");
+    using PC = typename Opacity::PC;
 
     lkappaPlanck_.resize(NRho, NT, NYe, NEUTRINO_NTYPES);
     // index 0 is the species and is not interpolatable
@@ -224,10 +220,8 @@ class MeanOpacity {
 
 } // namespace impl
 
-using MeanOpacityScaleFree = impl::MeanOpacity<PhysicalConstantsUnity>;
-using MeanOpacityCGS = impl::MeanOpacity<PhysicalConstantsCGS>;
-using MeanOpacity = impl::MeanVariant<MeanOpacityScaleFree, MeanOpacityCGS,
-                                      MeanNonCGSUnits<MeanOpacityCGS>>;
+using MeanOpacity =
+    impl::MeanVariant<impl::MeanOpacity, MeanNonCGSUnits<impl::MeanOpacity>>;
 
 } // namespace neutrinos
 } // namespace singularity

--- a/singularity-opac/neutrinos/mean_opacity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/mean_opacity_neutrinos.hpp
@@ -102,6 +102,10 @@ class MeanOpacity {
     return other;
   }
 
+  PORTABLE_INLINE_FUNCTION
+  pc GetPhysicalConstants() const { return pc(); }
+  // static pc GetPhysicalConstants() { return pc(); }
+
   void Finalize() {
     lkappaPlanck_.finalize();
     lkappaRosseland_.finalize();

--- a/singularity-opac/neutrinos/mean_opacity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/mean_opacity_neutrinos.hpp
@@ -41,6 +41,8 @@ template <typename pc = PhysicalConstantsCGS>
 class MeanOpacity {
 
  public:
+  using PC = pc;
+
   MeanOpacity() = default;
   template <typename Opacity>
   MeanOpacity(const Opacity &opac, const Real lRhoMin, const Real lRhoMax,
@@ -102,9 +104,6 @@ class MeanOpacity {
     return other;
   }
 
-  PORTABLE_INLINE_FUNCTION
-  pc GetPhysicalConstants() const { return pc(); }
-
   void Finalize() {
     lkappaPlanck_.finalize();
     lkappaRosseland_.finalize();
@@ -137,6 +136,9 @@ class MeanOpacity {
                         const Real lTMax, const int NT, const Real YeMin,
                         const Real YeMax, const int NYe, Real lNuMin,
                         Real lNuMax, const int NNu, Real *lambda = nullptr) {
+    static_assert(std::is_same<PC, typename Opacity::PC>::value,
+                  "Mean opacity constants must match opacity constants");
+
     lkappaPlanck_.resize(NRho, NT, NYe, NEUTRINO_NTYPES);
     // index 0 is the species and is not interpolatable
     lkappaPlanck_.setRange(1, YeMin, YeMax, NYe);
@@ -162,8 +164,8 @@ class MeanOpacity {
             // Choose default temperature-specific frequency grid if frequency
             // grid not specified
             if (AUTOFREQ) {
-              lNuMin = toLog_(1.e-3 * pc::kb * fromLog_(lTMin) / pc::h);
-              lNuMax = toLog_(1.e3 * pc::kb * fromLog_(lTMax) / pc::h);
+              lNuMin = toLog_(1.e-3 * PC::kb * fromLog_(lTMin) / PC::h);
+              lNuMax = toLog_(1.e3 * PC::kb * fromLog_(lTMax) / PC::h);
             }
             const Real dlnu = (lNuMax - lNuMin) / (NNu - 1);
             // Integrate over frequency

--- a/singularity-opac/neutrinos/mean_opacity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/mean_opacity_neutrinos.hpp
@@ -220,8 +220,9 @@ class MeanOpacity {
 
 } // namespace impl
 
+using MeanOpacityBase = impl::MeanOpacity;
 using MeanOpacity =
-    impl::MeanVariant<impl::MeanOpacity, MeanNonCGSUnits<impl::MeanOpacity>>;
+    impl::MeanVariant<MeanOpacityBase, MeanNonCGSUnits<MeanOpacityBase>>;
 
 } // namespace neutrinos
 } // namespace singularity

--- a/singularity-opac/neutrinos/neutrino_variant.hpp
+++ b/singularity-opac/neutrinos/neutrino_variant.hpp
@@ -71,6 +71,16 @@ class Variant {
         opac_);
   }
 
+  PORTABLE_INLINE_FUNCTION RuntimePhysicalConstants
+  GetRuntimePhysicalConstants() const {
+    return mpark::visit(
+        [=](const auto &opac) {
+          using PC = typename std::decay_t<decltype(opac)>::PC;
+          return singularity::GetRuntimePhysicalConstants(PC());
+        },
+        opac_);
+  }
+
   // Directional absorption coefficient with units of 1/length
   // Signature should be at least
   // rho, temp, Ye, type, nu, lambda
@@ -290,11 +300,12 @@ class Variant {
                         opac_);
   }
 
-  template <typename T>
-  PORTABLE_INLINE_FUNCTION T GetPhysicalConstants() const {
-    return mpark::visit([](auto &opac) { return opac.GetPhysicalConstants(); },
-                        opac_);
-  }
+  // template <typename T>
+  // PORTABLE_INLINE_FUNCTION T GetPhysicalConstants() const {
+  //  return mpark::visit([](auto &opac) { return opac.GetPhysicalConstants();
+  //  },
+  //                      opac_);
+  //}
 
   inline void Finalize() noexcept {
     return mpark::visit([](auto &opac) { return opac.Finalize(); }, opac_);

--- a/singularity-opac/neutrinos/neutrino_variant.hpp
+++ b/singularity-opac/neutrinos/neutrino_variant.hpp
@@ -1,5 +1,5 @@
 // ======================================================================
-// © 2021. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2024. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract
 // 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
 // is operated by Triad National Security, LLC for the U.S.

--- a/singularity-opac/neutrinos/neutrino_variant.hpp
+++ b/singularity-opac/neutrinos/neutrino_variant.hpp
@@ -290,6 +290,12 @@ class Variant {
                         opac_);
   }
 
+  template <typename T>
+  PORTABLE_INLINE_FUNCTION T GetPhysicalConstants() const {
+    return mpark::visit([](auto &opac) { return opac.GetPhysicalConstants(); },
+                        opac_);
+  }
+
   inline void Finalize() noexcept {
     return mpark::visit([](auto &opac) { return opac.Finalize(); }, opac_);
   }

--- a/singularity-opac/neutrinos/neutrino_variant.hpp
+++ b/singularity-opac/neutrinos/neutrino_variant.hpp
@@ -300,13 +300,6 @@ class Variant {
                         opac_);
   }
 
-  // template <typename T>
-  // PORTABLE_INLINE_FUNCTION T GetPhysicalConstants() const {
-  //  return mpark::visit([](auto &opac) { return opac.GetPhysicalConstants();
-  //  },
-  //                      opac_);
-  //}
-
   inline void Finalize() noexcept {
     return mpark::visit([](auto &opac) { return opac.Finalize(); }, opac_);
   }

--- a/singularity-opac/neutrinos/non_cgs_neutrinos.hpp
+++ b/singularity-opac/neutrinos/non_cgs_neutrinos.hpp
@@ -1,5 +1,5 @@
 // ======================================================================
-// © 2021. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2024. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract
 // 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
 // is operated by Triad National Security, LLC for the U.S.
@@ -265,6 +265,12 @@ class MeanNonCGSUnits {
 
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept { return mean_opac_.nlambda(); }
+
+#ifdef SPINER_USE_HDF
+  void Save(const std::string &filename) const {
+    return mean_opac_.Save(filename);
+  }
+#endif
 
   PORTABLE_INLINE_FUNCTION
   Real PlanckMeanAbsorptionCoefficient(const Real rho, const Real temp,

--- a/singularity-opac/neutrinos/non_cgs_neutrinos.hpp
+++ b/singularity-opac/neutrinos/non_cgs_neutrinos.hpp
@@ -47,6 +47,12 @@ class NonCGSUnits {
     return NonCGSUnits<Opac>(opac_.GetOnDevice(), time_unit_, mass_unit_,
                              length_unit_, temp_unit_);
   }
+
+  template <typename T>
+  PORTABLE_INLINE_FUNCTION T GetPhysicalConstants() const {
+    return opac_.GetPhysicalConstants();
+  }
+
   inline void Finalize() noexcept { opac_.Finalize(); }
 
   PORTABLE_INLINE_FUNCTION
@@ -66,10 +72,11 @@ class NonCGSUnits {
   }
 
   template <typename FrequencyIndexer, typename DataIndexer>
-  PORTABLE_INLINE_FUNCTION void AbsorptionCoefficient(
-      const Real rho, const Real temp, const Real Ye, RadiationType type,
-      FrequencyIndexer &nu_bins, DataIndexer &coeffs, const int nbins,
-      Real *lambda = nullptr) const {
+  PORTABLE_INLINE_FUNCTION void
+  AbsorptionCoefficient(const Real rho, const Real temp, const Real Ye,
+                        RadiationType type, FrequencyIndexer &nu_bins,
+                        DataIndexer &coeffs, const int nbins,
+                        Real *lambda = nullptr) const {
     for (int i = 0; i < nbins; ++i) {
       nu_bins[i] *= freq_unit_;
     }

--- a/singularity-opac/neutrinos/non_cgs_neutrinos.hpp
+++ b/singularity-opac/neutrinos/non_cgs_neutrinos.hpp
@@ -29,6 +29,8 @@ namespace neutrinos {
 template <typename Opac>
 class NonCGSUnits {
  public:
+  using PC = typename Opac::PC;
+
   NonCGSUnits() = default;
   NonCGSUnits(Opac &&opac, const Real time_unit, const Real mass_unit,
               const Real length_unit, const Real temp_unit)
@@ -46,11 +48,6 @@ class NonCGSUnits {
   auto GetOnDevice() {
     return NonCGSUnits<Opac>(opac_.GetOnDevice(), time_unit_, mass_unit_,
                              length_unit_, temp_unit_);
-  }
-
-  template <typename T>
-  PORTABLE_INLINE_FUNCTION T GetPhysicalConstants() const {
-    return opac_.GetPhysicalConstants();
   }
 
   inline void Finalize() noexcept { opac_.Finalize(); }

--- a/singularity-opac/neutrinos/spiner_opac_neutrinos.hpp
+++ b/singularity-opac/neutrinos/spiner_opac_neutrinos.hpp
@@ -61,6 +61,7 @@ enum class DataStatus { Deallocated, OnDevice, OnHost };
 template <typename ThermalDistribution, typename pc = PhysicalConstantsCGS>
 class SpinerOpacity {
  public:
+  using PC = pc;
   using DataBox = Spiner::DataBox<Real>;
   static constexpr Real EPS = 10.0 * std::numeric_limits<Real>::min();
   static constexpr Real Hz2MeV = pc::h / (1e6 * pc::eV);
@@ -110,7 +111,8 @@ class SpinerOpacity {
             Real J = std::max(opac.Emissivity(rho, T * MeV2K, Ye, type), 0.0);
             Real lJ = toLog_(J);
             lJ_(iRho, iT, iYe, idx) = lJ;
-            Real JYe = std::max(opac.NumberEmissivity(rho, T * MeV2K, Ye, type), 0.0);
+            Real JYe =
+                std::max(opac.NumberEmissivity(rho, T * MeV2K, Ye, type), 0.0);
             lJYe_(iRho, iT, iYe, idx) = toLog_(JYe);
             for (int ie = 0; ie < Ne; ++ie) {
               Real lE = lalphanu_.range(0).x(ie);
@@ -119,8 +121,8 @@ class SpinerOpacity {
               Real alpha = std::max(
                   opac.AbsorptionCoefficient(rho, T, Ye, type, nu), 0.0);
               lalphanu_(iRho, iT, iYe, idx, ie) = toLog_(alpha);
-              Real j = std::max(opac.EmissivityPerNuOmega(rho, T * MeV2K, Ye, type, nu),
-                                0.0);
+              Real j = std::max(
+                  opac.EmissivityPerNuOmega(rho, T * MeV2K, Ye, type, nu), 0.0);
               ljnu_(iRho, iT, iYe, idx, ie) = toLog_(j);
             }
           }
@@ -131,8 +133,8 @@ class SpinerOpacity {
 
   // DataBox constructor. Note that this constructor *shallow* copies
   // the databoxes, so they must be managed externally.
-  SpinerOpacity(const DataBox &lalphanu, const DataBox ljnu,
-                const DataBox lJ, const DataBox lJYe)
+  SpinerOpacity(const DataBox &lalphanu, const DataBox ljnu, const DataBox lJ,
+                const DataBox lJYe)
       : memoryStatus_(impl::DataStatus::OnHost), lalphanu_(lalphanu),
         ljnu_(ljnu), lJ_(lJ), lJYe_(lJYe) {}
 

--- a/singularity-opac/neutrinos/spiner_opac_neutrinos.hpp
+++ b/singularity-opac/neutrinos/spiner_opac_neutrinos.hpp
@@ -1,5 +1,5 @@
 // ======================================================================
-// © 2021. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2024. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract
 // 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
 // is operated by Triad National Security, LLC for the U.S.
@@ -63,6 +63,7 @@ class SpinerOpacity {
  public:
   using PC = pc;
   using DataBox = Spiner::DataBox<Real>;
+
   static constexpr Real EPS = 10.0 * std::numeric_limits<Real>::min();
   static constexpr Real Hz2MeV = pc::h / (1e6 * pc::eV);
   static constexpr Real MeV2Hz = 1 / Hz2MeV;

--- a/singularity-opac/neutrinos/tophat_emissivity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/tophat_emissivity_neutrinos.hpp
@@ -32,6 +32,8 @@ namespace neutrinos {
 template <typename ThermalDistribution, typename pc = PhysicalConstantsCGS>
 class TophatEmissivity {
  public:
+  using PC = pc;
+
   TophatEmissivity(const Real C, const Real numin, const Real numax)
       : C_(C), numin_(numin), numax_(numax) {}
   TophatEmissivity(const ThermalDistribution &dist, const Real C,

--- a/singularity-opac/neutrinos/tophat_emissivity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/tophat_emissivity_neutrinos.hpp
@@ -46,6 +46,10 @@ class TophatEmissivity {
     printf("Tophat emissivity. C, numin, numax = %g, %g, %g\n", C_, numin_,
            numax_);
   }
+
+  PORTABLE_INLINE_FUNCTION
+  pc GetPhysicalConstants() const { return pc(); }
+
   inline void Finalize() noexcept {}
 
   PORTABLE_INLINE_FUNCTION

--- a/singularity-opac/neutrinos/tophat_emissivity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/tophat_emissivity_neutrinos.hpp
@@ -1,5 +1,5 @@
 // ======================================================================
-// © 2021. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2024. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract
 // 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
 // is operated by Triad National Security, LLC for the U.S.

--- a/singularity-opac/neutrinos/tophat_emissivity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/tophat_emissivity_neutrinos.hpp
@@ -49,9 +49,6 @@ class TophatEmissivity {
            numax_);
   }
 
-  PORTABLE_INLINE_FUNCTION
-  pc GetPhysicalConstants() const { return pc(); }
-
   inline void Finalize() noexcept {}
 
   PORTABLE_INLINE_FUNCTION

--- a/singularity-opac/photons/epbremsstrahlung_opacity_photons.hpp
+++ b/singularity-opac/photons/epbremsstrahlung_opacity_photons.hpp
@@ -42,6 +42,10 @@ class EPBremsstrahlungOpacity {
   void PrintParams() const noexcept {
     printf("Electron-proton bremsstrahlung opacity.\n");
   }
+
+  PORTABLE_INLINE_FUNCTION
+  pc GetPhysicalConstants() const { return pc(); }
+
   inline void Finalize() noexcept {}
 
   PORTABLE_INLINE_FUNCTION

--- a/singularity-opac/photons/epbremsstrahlung_opacity_photons.hpp
+++ b/singularity-opac/photons/epbremsstrahlung_opacity_photons.hpp
@@ -1,5 +1,5 @@
 // ======================================================================
-// © 2022. Triad National Security, LLC. All rights reserved.  This
+// © 2022-2024. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract
 // 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
 // is operated by Triad National Security, LLC for the U.S.

--- a/singularity-opac/photons/epbremsstrahlung_opacity_photons.hpp
+++ b/singularity-opac/photons/epbremsstrahlung_opacity_photons.hpp
@@ -32,6 +32,8 @@ namespace photons {
 template <typename pc = PhysicalConstantsCGS>
 class EPBremsstrahlungOpacity {
  public:
+  using PC = pc;
+
   EPBremsstrahlungOpacity() = default;
   EPBremsstrahlungOpacity(const PlanckDistribution<pc> &dist) : dist_(dist) {}
 

--- a/singularity-opac/photons/gray_opacity_photons.hpp
+++ b/singularity-opac/photons/gray_opacity_photons.hpp
@@ -42,6 +42,10 @@ class GrayOpacity {
   void PrintParams() const noexcept {
     printf("Gray opacity. kappa = %g\n", kappa_);
   }
+
+  PORTABLE_INLINE_FUNCTION
+  pc GetPhysicalConstants() const { return pc(); }
+
   inline void Finalize() noexcept {}
 
   PORTABLE_INLINE_FUNCTION
@@ -164,9 +168,6 @@ class GrayOpacity {
                                     Real *lambda = nullptr) const {
     return dist_.NumberDensityFromTemperature(temp, lambda);
   }
-
-  PORTABLE_INLINE_FUNCTION
-  pc GetPhysicalConstants() const { return pc(); }
 
  private:
   Real kappa_; // Opacity. Units of cm^2/g

--- a/singularity-opac/photons/gray_opacity_photons.hpp
+++ b/singularity-opac/photons/gray_opacity_photons.hpp
@@ -30,6 +30,8 @@ namespace photons {
 template <typename pc = PhysicalConstantsCGS>
 class GrayOpacity {
  public:
+  using PC = pc;
+
   GrayOpacity() = default;
   GrayOpacity(const Real kappa) : kappa_(kappa) {}
   GrayOpacity(const PlanckDistribution<pc> &dist, const Real kappa)

--- a/singularity-opac/photons/gray_opacity_photons.hpp
+++ b/singularity-opac/photons/gray_opacity_photons.hpp
@@ -165,6 +165,9 @@ class GrayOpacity {
     return dist_.NumberDensityFromTemperature(temp, lambda);
   }
 
+  PORTABLE_INLINE_FUNCTION
+  pc GetPhysicalConstants() const { return pc(); }
+
  private:
   Real kappa_; // Opacity. Units of cm^2/g
   PlanckDistribution<pc> dist_;

--- a/singularity-opac/photons/gray_opacity_photons.hpp
+++ b/singularity-opac/photons/gray_opacity_photons.hpp
@@ -45,9 +45,6 @@ class GrayOpacity {
     printf("Gray opacity. kappa = %g\n", kappa_);
   }
 
-  PORTABLE_INLINE_FUNCTION
-  pc GetPhysicalConstants() const { return pc(); }
-
   inline void Finalize() noexcept {}
 
   PORTABLE_INLINE_FUNCTION

--- a/singularity-opac/photons/gray_opacity_photons.hpp
+++ b/singularity-opac/photons/gray_opacity_photons.hpp
@@ -44,7 +44,6 @@ class GrayOpacity {
   void PrintParams() const noexcept {
     printf("Gray opacity. kappa = %g\n", kappa_);
   }
-
   inline void Finalize() noexcept {}
 
   PORTABLE_INLINE_FUNCTION

--- a/singularity-opac/photons/gray_opacity_photons.hpp
+++ b/singularity-opac/photons/gray_opacity_photons.hpp
@@ -1,5 +1,5 @@
 // ======================================================================
-// © 2021. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2024. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract
 // 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
 // is operated by Triad National Security, LLC for the U.S.

--- a/singularity-opac/photons/mean_opacity_photons.hpp
+++ b/singularity-opac/photons/mean_opacity_photons.hpp
@@ -119,6 +119,9 @@ class MeanOpacity {
     return rho * fromLog_(lkappaRosseland_.interpToReal(lRho, lT));
   }
 
+  PORTABLE_INLINE_FUNCTION
+  pc GetPhysicalConstants() const { return pc(); }
+
  private:
   template <typename Opacity, bool AUTOFREQ>
   void MeanOpacityImpl_(const Opacity &opac, const Real lRhoMin,

--- a/singularity-opac/photons/mean_opacity_photons.hpp
+++ b/singularity-opac/photons/mean_opacity_photons.hpp
@@ -196,8 +196,9 @@ class MeanOpacity {
 
 } // namespace impl
 
+using MeanOpacityBase = impl::MeanOpacity;
 using MeanOpacity =
-    impl::MeanVariant<impl::MeanOpacity, MeanNonCGSUnits<impl::MeanOpacity>>;
+    impl::MeanVariant<MeanOpacityBase, MeanNonCGSUnits<MeanOpacityBase>>;
 
 } // namespace photons
 } // namespace singularity

--- a/singularity-opac/photons/mean_opacity_photons.hpp
+++ b/singularity-opac/photons/mean_opacity_photons.hpp
@@ -1,5 +1,5 @@
 // ======================================================================
-// © 2022. Triad National Security, LLC. All rights reserved.  This
+// © 2022-2024. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract
 // 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
 // is operated by Triad National Security, LLC for the U.S.

--- a/singularity-opac/photons/mean_opacity_photons.hpp
+++ b/singularity-opac/photons/mean_opacity_photons.hpp
@@ -37,12 +37,9 @@ namespace impl {
 // TODO(BRR) Note: It is assumed that lambda is constant for all densities and
 // temperatures
 
-template <typename pc = PhysicalConstantsCGS>
 class MeanOpacity {
 
  public:
-  using PC = pc;
-
   MeanOpacity() = default;
   template <typename Opacity>
   MeanOpacity(const Opacity &opac, const Real lRhoMin, const Real lRhoMax,
@@ -126,8 +123,7 @@ class MeanOpacity {
                         const Real lRhoMax, const int NRho, const Real lTMin,
                         const Real lTMax, const int NT, Real lNuMin,
                         Real lNuMax, const int NNu, Real *lambda = nullptr) {
-    static_assert(std::is_same<PC, typename Opacity::PC>::value,
-                  "Mean opacity constants must match opacity constants");
+    using PC = typename Opacity::PC;
 
     lkappaPlanck_.resize(NRho, NT);
     lkappaPlanck_.setRange(0, lTMin, lTMax, NT);
@@ -200,10 +196,8 @@ class MeanOpacity {
 
 } // namespace impl
 
-using MeanOpacityScaleFree = impl::MeanOpacity<PhysicalConstantsUnity>;
-using MeanOpacityCGS = impl::MeanOpacity<PhysicalConstantsCGS>;
-using MeanOpacity = impl::MeanVariant<MeanOpacityScaleFree, MeanOpacityCGS,
-                                      MeanNonCGSUnits<MeanOpacityCGS>>;
+using MeanOpacity =
+    impl::MeanVariant<impl::MeanOpacity, MeanNonCGSUnits<impl::MeanOpacity>>;
 
 } // namespace photons
 } // namespace singularity

--- a/singularity-opac/photons/mean_photon_variant.hpp
+++ b/singularity-opac/photons/mean_photon_variant.hpp
@@ -28,7 +28,7 @@ namespace singularity {
 namespace photons {
 namespace impl {
 
-template <typename PC, typename... Opacs>
+template <typename... Opacs>
 class MeanVariant {
  private:
   opac_variant<Opacs...> opac_;
@@ -86,13 +86,18 @@ class MeanVariant {
         opac_);
   }
 
-  PORTABLE_INLINE_FUNCTION PC GetPhysicalConstants() const {
-    return mpark::visit([](auto &opac) { return opac.GetPhysicalConstants(); },
-                        opac_);
-  }
-
   inline void Finalize() noexcept {
     return mpark::visit([](auto &opac) { return opac.Finalize(); }, opac_);
+  }
+
+  PORTABLE_INLINE_FUNCTION RuntimePhysicalConstants
+  GetRuntimePhysicalConstants() const {
+    return mpark::visit(
+        [=](const auto &opac) {
+          using PC = typename std::decay_t<decltype(opac)>::PC;
+          return singularity::GetRuntimePhysicalConstants(PC());
+        },
+        opac_);
   }
 };
 

--- a/singularity-opac/photons/mean_photon_variant.hpp
+++ b/singularity-opac/photons/mean_photon_variant.hpp
@@ -28,7 +28,7 @@ namespace singularity {
 namespace photons {
 namespace impl {
 
-template <typename... Opacs>
+template <typename CONSTANTS, typename... Opacs>
 class MeanVariant {
  private:
   opac_variant<Opacs...> opac_;
@@ -84,6 +84,11 @@ class MeanVariant {
           return opac.RosselandMeanAbsorptionCoefficient(rho, temp);
         },
         opac_);
+  }
+
+  PORTABLE_INLINE_FUNCTION CONSTANTS GetPhysicalConstants() const {
+    return mpark::visit([](auto &opac) { return opac.GetPhysicalConstants(); },
+                        opac_);
   }
 
   inline void Finalize() noexcept {

--- a/singularity-opac/photons/mean_photon_variant.hpp
+++ b/singularity-opac/photons/mean_photon_variant.hpp
@@ -69,6 +69,16 @@ class MeanVariant {
         opac_);
   }
 
+  PORTABLE_INLINE_FUNCTION RuntimePhysicalConstants
+  GetRuntimePhysicalConstants() const {
+    return mpark::visit(
+        [=](const auto &opac) {
+          using PC = typename std::decay_t<decltype(opac)>::PC;
+          return singularity::GetRuntimePhysicalConstants(PC());
+        },
+        opac_);
+  }
+
   PORTABLE_INLINE_FUNCTION Real
   PlanckMeanAbsorptionCoefficient(const Real rho, const Real temp) const {
     return mpark::visit(
@@ -90,15 +100,11 @@ class MeanVariant {
     return mpark::visit([](auto &opac) { return opac.Finalize(); }, opac_);
   }
 
-  PORTABLE_INLINE_FUNCTION RuntimePhysicalConstants
-  GetRuntimePhysicalConstants() const {
-    return mpark::visit(
-        [=](const auto &opac) {
-          using PC = typename std::decay_t<decltype(opac)>::PC;
-          return singularity::GetRuntimePhysicalConstants(PC());
-        },
-        opac_);
+#ifdef SPINER_USE_HDF
+  void Save(const std::string &filename) const {
+    return mpark::visit([=](auto &opac) { return opac.Save(filename); }, opac_);
   }
+#endif
 };
 
 } // namespace impl

--- a/singularity-opac/photons/mean_photon_variant.hpp
+++ b/singularity-opac/photons/mean_photon_variant.hpp
@@ -1,5 +1,5 @@
 // ======================================================================
-// © 2022. Triad National Security, LLC. All rights reserved.  This
+// © 2022-2024. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract
 // 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
 // is operated by Triad National Security, LLC for the U.S.
@@ -28,7 +28,7 @@ namespace singularity {
 namespace photons {
 namespace impl {
 
-template <typename CONSTANTS, typename... Opacs>
+template <typename PC, typename... Opacs>
 class MeanVariant {
  private:
   opac_variant<Opacs...> opac_;
@@ -86,7 +86,7 @@ class MeanVariant {
         opac_);
   }
 
-  PORTABLE_INLINE_FUNCTION CONSTANTS GetPhysicalConstants() const {
+  PORTABLE_INLINE_FUNCTION PC GetPhysicalConstants() const {
     return mpark::visit([](auto &opac) { return opac.GetPhysicalConstants(); },
                         opac_);
   }

--- a/singularity-opac/photons/non_cgs_photons.hpp
+++ b/singularity-opac/photons/non_cgs_photons.hpp
@@ -29,6 +29,8 @@ namespace photons {
 template <typename Opac>
 class NonCGSUnits {
  public:
+  using PC = typename Opac::PC;
+
   NonCGSUnits() = default;
   NonCGSUnits(Opac &&opac, const Real time_unit, const Real mass_unit,
               const Real length_unit, const Real temp_unit)

--- a/singularity-opac/photons/non_cgs_photons.hpp
+++ b/singularity-opac/photons/non_cgs_photons.hpp
@@ -254,6 +254,12 @@ class MeanNonCGSUnits {
   PORTABLE_INLINE_FUNCTION
   int nlambda() const noexcept { return mean_opac_.nlambda(); }
 
+#ifdef SPINER_USE_HDF
+  void Save(const std::string &filename) const {
+    return mean_opac_.Save(filename);
+  }
+#endif
+
   PORTABLE_INLINE_FUNCTION
   Real PlanckMeanAbsorptionCoefficient(const Real rho, const Real temp) const {
     const Real alpha = mean_opac_.PlanckMeanAbsorptionCoefficient(

--- a/singularity-opac/photons/non_cgs_photons.hpp
+++ b/singularity-opac/photons/non_cgs_photons.hpp
@@ -65,9 +65,10 @@ class NonCGSUnits {
   }
 
   template <typename FrequencyIndexer, typename DataIndexer>
-  PORTABLE_INLINE_FUNCTION void AbsorptionCoefficient(
-      const Real rho, const Real temp, FrequencyIndexer &nu_bins,
-      DataIndexer &coeffs, const int nbins, Real *lambda = nullptr) const {
+  PORTABLE_INLINE_FUNCTION void
+  AbsorptionCoefficient(const Real rho, const Real temp,
+                        FrequencyIndexer &nu_bins, DataIndexer &coeffs,
+                        const int nbins, Real *lambda = nullptr) const {
     for (int i = 0; i < nbins; ++i) {
       nu_bins[i] *= freq_unit_;
     }
@@ -217,6 +218,11 @@ class NonCGSUnits {
                                     Real *lambda = nullptr) const {
     Real NoH = opac_.NumberDensityFromTemperature(temp * temp_unit_, lambda);
     return NoH * mass_unit_ / rho_unit_;
+  }
+
+  template <typename T>
+  PORTABLE_INLINE_FUNCTION T GetPhysicalConstants() const {
+    return opac_.GetPhysicalConstants();
   }
 
  private:

--- a/singularity-opac/photons/photon_variant.hpp
+++ b/singularity-opac/photons/photon_variant.hpp
@@ -285,13 +285,6 @@ class Variant {
                         opac_);
   }
 
-  // template <typename T>
-  // PORTABLE_INLINE_FUNCTION T GetPhysicalConstants() const {
-  //  return mpark::visit([](auto &opac) { return opac.GetPhysicalConstants();
-  //  },
-  //                      opac_);
-  //}
-
   inline void Finalize() noexcept {
     return mpark::visit([](auto &opac) { return opac.Finalize(); }, opac_);
   }

--- a/singularity-opac/photons/photon_variant.hpp
+++ b/singularity-opac/photons/photon_variant.hpp
@@ -30,7 +30,7 @@ namespace impl {
 template <typename... Ts>
 using opac_variant = mpark::variant<Ts...>;
 
-template <typename CONSTANTS, typename... Opacs>
+template <typename... Opacs>
 class Variant {
  private:
   opac_variant<Opacs...> opac_;
@@ -275,7 +275,8 @@ class Variant {
                         opac_);
   }
 
-  PORTABLE_INLINE_FUNCTION CONSTANTS GetPhysicalConstants() const {
+  template <typename T>
+  PORTABLE_INLINE_FUNCTION T GetPhysicalConstants() const {
     return mpark::visit([](auto &opac) { return opac.GetPhysicalConstants(); },
                         opac_);
   }

--- a/singularity-opac/photons/photon_variant.hpp
+++ b/singularity-opac/photons/photon_variant.hpp
@@ -71,6 +71,16 @@ class Variant {
         opac_);
   }
 
+  PORTABLE_INLINE_FUNCTION RuntimePhysicalConstants
+  GetRuntimePhysicalConstants() const {
+    return mpark::visit(
+        [=](const auto &opac) {
+          using PC = typename std::decay_t<decltype(opac)>::PC;
+          return singularity::GetRuntimePhysicalConstants(PC());
+        },
+        opac_);
+  }
+
   // Directional absorption coefficient with units of 1/length
   // Signature should be at least
   // rho, temp, nu, lambda
@@ -275,11 +285,12 @@ class Variant {
                         opac_);
   }
 
-  template <typename T>
-  PORTABLE_INLINE_FUNCTION T GetPhysicalConstants() const {
-    return mpark::visit([](auto &opac) { return opac.GetPhysicalConstants(); },
-                        opac_);
-  }
+  // template <typename T>
+  // PORTABLE_INLINE_FUNCTION T GetPhysicalConstants() const {
+  //  return mpark::visit([](auto &opac) { return opac.GetPhysicalConstants();
+  //  },
+  //                      opac_);
+  //}
 
   inline void Finalize() noexcept {
     return mpark::visit([](auto &opac) { return opac.Finalize(); }, opac_);

--- a/singularity-opac/photons/photon_variant.hpp
+++ b/singularity-opac/photons/photon_variant.hpp
@@ -1,5 +1,5 @@
 // ======================================================================
-// © 2021. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2024. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract
 // 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
 // is operated by Triad National Security, LLC for the U.S.

--- a/singularity-opac/photons/photon_variant.hpp
+++ b/singularity-opac/photons/photon_variant.hpp
@@ -30,7 +30,7 @@ namespace impl {
 template <typename... Ts>
 using opac_variant = mpark::variant<Ts...>;
 
-template <typename... Opacs>
+template <typename CONSTANTS, typename... Opacs>
 class Variant {
  private:
   opac_variant<Opacs...> opac_;
@@ -272,6 +272,11 @@ class Variant {
   PORTABLE_INLINE_FUNCTION
   void PrintParams() const noexcept {
     return mpark::visit([](const auto &opac) { return opac.PrintParams(); },
+                        opac_);
+  }
+
+  PORTABLE_INLINE_FUNCTION CONSTANTS GetPhysicalConstants() const {
+    return mpark::visit([](auto &opac) { return opac.GetPhysicalConstants(); },
                         opac_);
   }
 

--- a/singularity-opac/photons/powerlaw_opacity_photons.hpp
+++ b/singularity-opac/photons/powerlaw_opacity_photons.hpp
@@ -45,6 +45,10 @@ class PowerLawOpacity {
     printf("Power law opacity. kappa0 = %g rho_exp = %g temp_exp = %g\n",
            kappa0_, rho_exp_, temp_exp_);
   }
+
+  PORTABLE_INLINE_FUNCTION
+  pc GetPhysicalConstants() const { return pc(); }
+
   inline void Finalize() noexcept {}
 
   PORTABLE_INLINE_FUNCTION

--- a/singularity-opac/photons/powerlaw_opacity_photons.hpp
+++ b/singularity-opac/photons/powerlaw_opacity_photons.hpp
@@ -30,6 +30,8 @@ namespace photons {
 template <typename pc = PhysicalConstantsCGS>
 class PowerLawOpacity {
  public:
+  using PC = pc;
+
   PowerLawOpacity() = default;
   PowerLawOpacity(const Real kappa0, const Real rho_exp, const Real temp_exp)
       : kappa0_(kappa0), rho_exp_(rho_exp), temp_exp_(temp_exp) {}

--- a/singularity-opac/photons/powerlaw_opacity_photons.hpp
+++ b/singularity-opac/photons/powerlaw_opacity_photons.hpp
@@ -47,10 +47,6 @@ class PowerLawOpacity {
     printf("Power law opacity. kappa0 = %g rho_exp = %g temp_exp = %g\n",
            kappa0_, rho_exp_, temp_exp_);
   }
-
-  PORTABLE_INLINE_FUNCTION
-  pc GetPhysicalConstants() const { return pc(); }
-
   inline void Finalize() noexcept {}
 
   PORTABLE_INLINE_FUNCTION

--- a/test/test_gray_opacities.cpp
+++ b/test/test_gray_opacities.cpp
@@ -1,5 +1,5 @@
 // ======================================================================
-// © 2021. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2024. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract
 // 89233218CNA000001 for Los Alamos National Laboratory (LANL), which
 // is operated by Triad National Security, LLC for the U.S.
@@ -57,8 +57,21 @@ TEST_CASE("Gray neutrino opacities", "[GrayNeutrinos]") {
     neutrinos::Gray opac_host(1);
     neutrinos::Opacity opac = opac_host.GetOnDevice();
 
-    auto constants = opac_host.GetPhysicalConstants();
-    printf("cl: %e\n", constants.c);
+    // Check constants from mean opacity
+    THEN("Check constants from mean opacity for consistency") {
+      auto constants = opac_host.GetPhysicalConstants();
+      int n_wrong = 0;
+      if (FractionalDifference(pc::eV, constants.eV) > EPS_TEST) {
+        n_wrong += 1;
+      }
+      if (FractionalDifference(pc::kb, constants.kb) > EPS_TEST) {
+        n_wrong += 1;
+      }
+      if (FractionalDifference(pc::h, constants.h) > EPS_TEST) {
+        n_wrong += 1;
+      }
+      REQUIRE(n_wrong == 0);
+    }
 
     THEN("The emissivity per nu omega is consistent with the emissity per nu") {
       int n_wrong_h = 0;
@@ -206,6 +219,23 @@ TEST_CASE("Gray photon opacities", "[GrayPhotons]") {
 
     photons::Opacity opac_host = photons::Gray(1);
     photons::Opacity opac = opac_host.GetOnDevice();
+
+    // Check constants from mean opacity
+    THEN("Check constants from mean opacity for consistency") {
+      auto constants = opac_host.GetPhysicalConstants();
+      int n_wrong = 0;
+      if (FractionalDifference(pc::eV, constants.eV) > EPS_TEST) {
+        n_wrong += 1;
+      }
+      if (FractionalDifference(pc::kb, constants.kb) > EPS_TEST) {
+        n_wrong += 1;
+      }
+      if (FractionalDifference(pc::h, constants.h) > EPS_TEST) {
+        n_wrong += 1;
+      }
+      REQUIRE(n_wrong == 0);
+    }
+
     THEN("The emissivity per nu omega is consistent with the emissity per nu") {
       int n_wrong_h = 0;
 #ifdef PORTABILITY_STRATEGY_KOKKOS

--- a/test/test_gray_opacities.cpp
+++ b/test/test_gray_opacities.cpp
@@ -54,12 +54,13 @@ TEST_CASE("Gray neutrino opacities", "[GrayNeutrinos]") {
     constexpr RadiationType type = RadiationType::NU_ELECTRON;
     constexpr Real nu = 1.25 * MeV2Hz; // 1 MeV
 
-    neutrinos::Gray opac_host(1);
+    // neutrinos::Gray opac_host(1);
+    neutrinos::Opacity opac_host = neutrinos::Gray(1);
     neutrinos::Opacity opac = opac_host.GetOnDevice();
 
-    // Check constants from mean opacity
+    // Check constants from opacity
     THEN("Check constants from mean opacity for consistency") {
-      auto constants = opac_host.GetPhysicalConstants();
+      auto constants = opac_host.GetRuntimePhysicalConstants();
       int n_wrong = 0;
       if (FractionalDifference(pc::eV, constants.eV) > EPS_TEST) {
         n_wrong += 1;
@@ -222,7 +223,7 @@ TEST_CASE("Gray photon opacities", "[GrayPhotons]") {
 
     // Check constants from mean opacity
     THEN("Check constants from mean opacity for consistency") {
-      auto constants = opac_host.GetPhysicalConstants();
+      auto constants = opac_host.GetRuntimePhysicalConstants();
       int n_wrong = 0;
       if (FractionalDifference(pc::eV, constants.eV) > EPS_TEST) {
         n_wrong += 1;

--- a/test/test_gray_opacities.cpp
+++ b/test/test_gray_opacities.cpp
@@ -54,8 +54,7 @@ TEST_CASE("Gray neutrino opacities", "[GrayNeutrinos]") {
     constexpr RadiationType type = RadiationType::NU_ELECTRON;
     constexpr Real nu = 1.25 * MeV2Hz; // 1 MeV
 
-    // neutrinos::Gray opac_host(1);
-    neutrinos::Opacity opac_host = neutrinos::Gray(1);
+    neutrinos::Opacity opac_host = neutrinos::Gray(1.);
     neutrinos::Opacity opac = opac_host.GetOnDevice();
 
     // Check constants from opacity

--- a/test/test_gray_opacities.cpp
+++ b/test/test_gray_opacities.cpp
@@ -57,6 +57,9 @@ TEST_CASE("Gray neutrino opacities", "[GrayNeutrinos]") {
     neutrinos::Gray opac_host(1);
     neutrinos::Opacity opac = opac_host.GetOnDevice();
 
+    auto constants = opac_host.GetPhysicalConstants();
+    printf("cl: %e\n", constants.c);
+
     THEN("The emissivity per nu omega is consistent with the emissity per nu") {
       int n_wrong_h = 0;
 #ifdef PORTABILITY_STRATEGY_KOKKOS
@@ -283,8 +286,7 @@ TEST_CASE("Gray photon opacities", "[GrayPhotons]") {
 
       Real *nu_bins = (Real *)PORTABLE_MALLOC(nbins * sizeof(Real));
       Real *temp_bins = (Real *)PORTABLE_MALLOC(ntemps * sizeof(Real));
-      DataBox loglin_bins(Spiner::AllocationTarget::Device, ntemps,
-                                  nbins);
+      DataBox loglin_bins(Spiner::AllocationTarget::Device, ntemps, nbins);
 
       portableFor(
           "set nu bins", 0, nbins, PORTABLE_LAMBDA(const int &i) {

--- a/test/test_mean_opacities.cpp
+++ b/test/test_mean_opacities.cpp
@@ -87,7 +87,7 @@ TEST_CASE("Mean neutrino opacities", "[MeanNeutrinos]") {
     neutrinos::Gray opac_host(kappa);
     neutrinos::Opacity opac = opac_host.GetOnDevice();
 
-    neutrinos::MeanOpacity mean_opac_host = neutrinos::impl::MeanOpacity(
+    neutrinos::MeanOpacity mean_opac_host = neutrinos::MeanOpacityBase(
         opac_host, lRhoMin, lRhoMax, NRho, lTMin, lTMax, NT, YeMin, YeMax, NYe);
     auto mean_opac = mean_opac_host.GetOnDevice();
 
@@ -412,7 +412,7 @@ TEST_CASE("Mean photon opacities", "[MeanPhotons]") {
     photons::Gray opac_host(kappa);
     photons::Opacity opac = opac_host.GetOnDevice();
 
-    photons::MeanOpacity mean_opac_host = photons::impl::MeanOpacity(
+    photons::MeanOpacity mean_opac_host = photons::MeanOpacityBase(
         opac_host, lRhoMin, lRhoMax, NRho, lTMin, lTMax, NT);
     auto mean_opac = mean_opac_host.GetOnDevice();
 
@@ -448,7 +448,7 @@ TEST_CASE("Mean photon opacities", "[MeanPhotons]") {
     THEN("We can save to disk and reload") {
       mean_opac.Save(grayname);
       photons::MeanOpacity mean_opac_host_load =
-          photons::impl::MeanOpacity(grayname);
+          photons::MeanOpacityBase(grayname);
       AND_THEN("The reloaded table matches the gray opacities") {
 
         auto mean_opac_load = mean_opac_host_load.GetOnDevice();

--- a/test/test_mean_opacities.cpp
+++ b/test/test_mean_opacities.cpp
@@ -447,7 +447,8 @@ TEST_CASE("Mean photon opacities", "[MeanPhotons]") {
 #ifdef SPINER_USE_HDF
     THEN("We can save to disk and reload") {
       mean_opac.Save(grayname);
-      photons::MeanOpacityCGS mean_opac_host_load(grayname);
+      photons::MeanOpacity mean_opac_host_load =
+          photons::impl::MeanOpacity(grayname);
       AND_THEN("The reloaded table matches the gray opacities") {
 
         auto mean_opac_load = mean_opac_host_load.GetOnDevice();

--- a/test/test_mean_opacities.cpp
+++ b/test/test_mean_opacities.cpp
@@ -268,7 +268,6 @@ TEST_CASE("Mean neutrino scattering opacities", "[MeanNeutrinosS]") {
 
     neutrinos::MeanSOpacityCGS mean_opac_host(
         opac_host, lRhoMin, lRhoMax, NRho, lTMin, lTMax, NT, YeMin, YeMax, NYe);
-    // neutrinos::MeanOpacity mean_opac = mean_opac_host.GetOnDevice();
     auto mean_opac = mean_opac_host.GetOnDevice();
 
     THEN("The emissivity per nu omega is consistent with the emissity per nu") {
@@ -432,6 +431,22 @@ TEST_CASE("Mean photon opacities", "[MeanPhotons]") {
     photons::MeanOpacityCGS mean_opac_host(opac_host, lRhoMin, lRhoMax, NRho,
                                            lTMin, lTMax, NT);
     auto mean_opac = mean_opac_host.GetOnDevice();
+
+    // Check constants from mean opacity
+    THEN("Check constants from mean opacity for consistency") {
+      auto constants = mean_opac_host.GetPhysicalConstants();
+      int n_wrong = 0;
+      if (FractionalDifference(pc::eV, constants.eV) > EPS_TEST) {
+        n_wrong += 1;
+      }
+      if (FractionalDifference(pc::kb, constants.kb) > EPS_TEST) {
+        n_wrong += 1;
+      }
+      if (FractionalDifference(pc::h, constants.h) > EPS_TEST) {
+        n_wrong += 1;
+      }
+      REQUIRE(n_wrong == 0);
+    }
 
     THEN("The emissivity per nu omega is consistent with the emissity per nu") {
       int n_wrong_h = 0;

--- a/test/test_mean_opacities.cpp
+++ b/test/test_mean_opacities.cpp
@@ -87,25 +87,9 @@ TEST_CASE("Mean neutrino opacities", "[MeanNeutrinos]") {
     neutrinos::Gray opac_host(kappa);
     neutrinos::Opacity opac = opac_host.GetOnDevice();
 
-    neutrinos::MeanOpacityCGS mean_opac_host(
+    neutrinos::MeanOpacity mean_opac_host = neutrinos::MeanOpacityCGS(
         opac_host, lRhoMin, lRhoMax, NRho, lTMin, lTMax, NT, YeMin, YeMax, NYe);
     auto mean_opac = mean_opac_host.GetOnDevice();
-
-    // Check constants from mean opacity
-    THEN("Check constants from mean opacity for consistency") {
-      auto constants = mean_opac_host.GetPhysicalConstants();
-      int n_wrong = 0;
-      if (FractionalDifference(pc::eV, constants.eV) > EPS_TEST) {
-        n_wrong += 1;
-      }
-      if (FractionalDifference(pc::kb, constants.kb) > EPS_TEST) {
-        n_wrong += 1;
-      }
-      if (FractionalDifference(pc::h, constants.h) > EPS_TEST) {
-        n_wrong += 1;
-      }
-      REQUIRE(n_wrong == 0);
-    }
 
     THEN("The emissivity per nu omega is consistent with the emissity per nu") {
       int n_wrong_h = 0;
@@ -138,7 +122,7 @@ TEST_CASE("Mean neutrino opacities", "[MeanNeutrinos]") {
 #ifdef SPINER_USE_HDF
     THEN("We can save to disk and reload") {
       mean_opac.Save(grayname);
-      neutrinos::MeanOpacityCGS mean_opac_host_load(grayname);
+      neutrinos::MeanOpacity mean_opac_host_load(grayname);
       AND_THEN("The reloaded table matches the gray opacities") {
 
         auto mean_opac_load = mean_opac_host_load.GetOnDevice();
@@ -428,25 +412,13 @@ TEST_CASE("Mean photon opacities", "[MeanPhotons]") {
     photons::Gray opac_host(kappa);
     photons::Opacity opac = opac_host.GetOnDevice();
 
+    // photons::MeanOpacity mean_opac_host = photons::MeanOpacityCGS(
+    //    opac_host, lRhoMin, lRhoMax, NRho, lTMin, lTMax, NT);
+    // auto mean_opac = mean_opac_host.GetOnDevice();
+
     photons::MeanOpacityCGS mean_opac_host(opac_host, lRhoMin, lRhoMax, NRho,
                                            lTMin, lTMax, NT);
     auto mean_opac = mean_opac_host.GetOnDevice();
-
-    // Check constants from mean opacity
-    THEN("Check constants from mean opacity for consistency") {
-      auto constants = mean_opac_host.GetPhysicalConstants();
-      int n_wrong = 0;
-      if (FractionalDifference(pc::eV, constants.eV) > EPS_TEST) {
-        n_wrong += 1;
-      }
-      if (FractionalDifference(pc::kb, constants.kb) > EPS_TEST) {
-        n_wrong += 1;
-      }
-      if (FractionalDifference(pc::h, constants.h) > EPS_TEST) {
-        n_wrong += 1;
-      }
-      REQUIRE(n_wrong == 0);
-    }
 
     THEN("The emissivity per nu omega is consistent with the emissity per nu") {
       int n_wrong_h = 0;
@@ -479,7 +451,7 @@ TEST_CASE("Mean photon opacities", "[MeanPhotons]") {
 #ifdef SPINER_USE_HDF
     THEN("We can save to disk and reload") {
       mean_opac.Save(grayname);
-      photons::MeanOpacityCGS mean_opac_host_load(grayname);
+      photons::MeanOpacity mean_opac_host_load(grayname);
       AND_THEN("The reloaded table matches the gray opacities") {
 
         auto mean_opac_load = mean_opac_host_load.GetOnDevice();
@@ -526,6 +498,10 @@ TEST_CASE("Mean photon opacities", "[MeanPhotons]") {
       constexpr Real rho_unit =
           mass_unit / (length_unit * length_unit * length_unit);
 
+      // auto funny_units_host =
+      // photons::MeanNonCGSUnits<photons::MeanOpacityCGS>(
+      //    std::forward<photons::MeanOpacityCGS>(mean_opac_host), time_unit,
+      //    mean_opac_host, time_unit, mass_unit, length_unit, temp_unit);
       auto funny_units_host = photons::MeanNonCGSUnits<photons::MeanOpacity>(
           std::forward<photons::MeanOpacity>(mean_opac_host), time_unit,
           mass_unit, length_unit, temp_unit);

--- a/test/test_mean_opacities.cpp
+++ b/test/test_mean_opacities.cpp
@@ -87,7 +87,7 @@ TEST_CASE("Mean neutrino opacities", "[MeanNeutrinos]") {
     neutrinos::Gray opac_host(kappa);
     neutrinos::Opacity opac = opac_host.GetOnDevice();
 
-    neutrinos::MeanOpacity mean_opac_host = neutrinos::MeanOpacityCGS(
+    neutrinos::MeanOpacity mean_opac_host = neutrinos::impl::MeanOpacity(
         opac_host, lRhoMin, lRhoMax, NRho, lTMin, lTMax, NT, YeMin, YeMax, NYe);
     auto mean_opac = mean_opac_host.GetOnDevice();
 
@@ -412,12 +412,8 @@ TEST_CASE("Mean photon opacities", "[MeanPhotons]") {
     photons::Gray opac_host(kappa);
     photons::Opacity opac = opac_host.GetOnDevice();
 
-    // photons::MeanOpacity mean_opac_host = photons::MeanOpacityCGS(
-    //    opac_host, lRhoMin, lRhoMax, NRho, lTMin, lTMax, NT);
-    // auto mean_opac = mean_opac_host.GetOnDevice();
-
-    photons::MeanOpacityCGS mean_opac_host(opac_host, lRhoMin, lRhoMax, NRho,
-                                           lTMin, lTMax, NT);
+    photons::MeanOpacity mean_opac_host = photons::impl::MeanOpacity(
+        opac_host, lRhoMin, lRhoMax, NRho, lTMin, lTMax, NT);
     auto mean_opac = mean_opac_host.GetOnDevice();
 
     THEN("The emissivity per nu omega is consistent with the emissity per nu") {
@@ -451,7 +447,7 @@ TEST_CASE("Mean photon opacities", "[MeanPhotons]") {
 #ifdef SPINER_USE_HDF
     THEN("We can save to disk and reload") {
       mean_opac.Save(grayname);
-      photons::MeanOpacity mean_opac_host_load(grayname);
+      photons::MeanOpacityCGS mean_opac_host_load(grayname);
       AND_THEN("The reloaded table matches the gray opacities") {
 
         auto mean_opac_load = mean_opac_host_load.GetOnDevice();
@@ -498,10 +494,6 @@ TEST_CASE("Mean photon opacities", "[MeanPhotons]") {
       constexpr Real rho_unit =
           mass_unit / (length_unit * length_unit * length_unit);
 
-      // auto funny_units_host =
-      // photons::MeanNonCGSUnits<photons::MeanOpacityCGS>(
-      //    std::forward<photons::MeanOpacityCGS>(mean_opac_host), time_unit,
-      //    mean_opac_host, time_unit, mass_unit, length_unit, temp_unit);
       auto funny_units_host = photons::MeanNonCGSUnits<photons::MeanOpacity>(
           std::forward<photons::MeanOpacity>(mean_opac_host), time_unit,
           mass_unit, length_unit, temp_unit);


### PR DESCRIPTION
It would be nice to see the physical constants being used by `singularity-opac` in downstream codes for consistency. This PR provides a way to do that, although we lose the `constexpr`ness of the constants with this approach (templating the variant to make `ReturnPhysicalConstants` a `static` method appears to be a tricky proposition). 