### PR TITLE
Fix mean opacities

### DIFF
--- a/singularity-opac/constants/constants.hpp
+++ b/singularity-opac/constants/constants.hpp
@@ -16,6 +16,9 @@
 #ifndef SINGULARITY_OPAC_CONSTANTS_CONSTANTS_
 #define SINGULARITY_OPAC_CONSTANTS_CONSTANTS_
 
+#include <cstring>
+#include <type_traits>
+
 #include <ports-of-call/portability.hpp>
 
 namespace singularity {
@@ -230,6 +233,11 @@ struct RuntimePhysicalConstants {
   const Real Fc;
   const Real nu_sigma0;
   const Real gA;
+
+  // Runtime physical constants are trivially copyable
+  bool operator==(const RuntimePhysicalConstants &other) const {
+    return std::memcmp(this, &other, sizeof(*this));
+  }
 };
 
 using PhysicalConstantsUnity =

--- a/singularity-opac/neutrinos/mean_opacity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/mean_opacity_neutrinos.hpp
@@ -140,9 +140,11 @@ class MeanOpacity {
                         const Real lTMax, const int NT, const Real YeMin,
                         const Real YeMax, const int NYe, Real lNuMin,
                         Real lNuMax, const int NNu, Real *lambda = nullptr) {
-    static_assert(std::is_same<typename Opacity::PC, PC>::value,
-                  "Error: MeanOpacity physical constants do not match those of "
-                  "Opacity used for construction.");
+#ifndef NDEBUG
+    auto RPC = RuntimePhysicalConstants(PC);
+    auto opc = opac.GetRuntimePhysicalConstants();
+    assert(RPC == opc && "Physical constants are the same");
+#endif
 
     lkappaPlanck_.resize(NRho, NT, NYe, NEUTRINO_NTYPES);
     // index 0 is the species and is not interpolatable

--- a/singularity-opac/neutrinos/mean_opacity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/mean_opacity_neutrinos.hpp
@@ -141,7 +141,7 @@ class MeanOpacity {
                         const Real YeMax, const int NYe, Real lNuMin,
                         Real lNuMax, const int NNu, Real *lambda = nullptr) {
 #ifndef NDEBUG
-    auto RPC = RuntimePhysicalConstants(PC);
+    auto RPC = RuntimePhysicalConstants(PC());
     auto opc = opac.GetRuntimePhysicalConstants();
     assert(RPC == opc && "Physical constants are the same");
 #endif

--- a/singularity-opac/photons/mean_opacity_photons.hpp
+++ b/singularity-opac/photons/mean_opacity_photons.hpp
@@ -149,9 +149,11 @@ class MeanOpacity {
                         const Real lRhoMax, const int NRho, const Real lTMin,
                         const Real lTMax, const int NT, Real lNuMin,
                         Real lNuMax, const int NNu, Real *lambda = nullptr) {
-    static_assert(std::is_same<typename Opacity::PC, PC>::value,
-                  "Error: MeanOpacity physical constants do not match those of "
-                  "Opacity used for construction.");
+#ifndef NDEBUG
+    auto RPC = RuntimePhysicalConstants(PC);
+    auto opc = opac.GetRuntimePhysicalConstants();
+    assert(RPC == opc && "Physical constants are the same");
+#endif
 
     lkappa_.resize(NRho, NT, 2);
     lkappa_.setRange(1, lTMin, lTMax, NT);

--- a/singularity-opac/photons/mean_opacity_photons.hpp
+++ b/singularity-opac/photons/mean_opacity_photons.hpp
@@ -150,7 +150,7 @@ class MeanOpacity {
                         const Real lTMax, const int NT, Real lNuMin,
                         Real lNuMax, const int NNu, Real *lambda = nullptr) {
 #ifndef NDEBUG
-    auto RPC = RuntimePhysicalConstants(PC);
+    auto RPC = RuntimePhysicalConstants(PC());
     auto opc = opac.GetRuntimePhysicalConstants();
     assert(RPC == opc && "Physical constants are the same");
 #endif


### PR DESCRIPTION
In the recent MR #58 where runtime physical constants were added, the mean opacities needed to be changed to not look for the compile time constants. I make that modification here. @AstroBarker saw this when trying to update singularity-opac in phoebus.

I know we are likely going to make more changes here soon to support Artemis + Riot but I think it's worth fixing this now, and then we can iterate later as needed.