### PR TITLE
Modify evaluation of absorption coefficients

### DIFF
--- a/singularity-opac/neutrinos/thermal_distributions_neutrinos.hpp
+++ b/singularity-opac/neutrinos/thermal_distributions_neutrinos.hpp
@@ -81,7 +81,7 @@ struct FermiDiracDistributionNoMu {
     return ThermalNumberDistributionOfT(temp, type, lambda) / pc::c;
   }
   template <typename Emissivity>
-  PORTABLE_INLINE_FUNCTION Real AbsorptionCoefficientFromKirkhoff(
+  PORTABLE_INLINE_FUNCTION Real AbsorptionCoefficientFromKirchhoff(
       const Emissivity &J, const Real rho, const Real temp, const Real Ye,
       const RadiationType type, const Real nu, Real *lambda = nullptr) const {
     const Real Bnu =
@@ -91,7 +91,7 @@ struct FermiDiracDistributionNoMu {
     return singularity_opac::robust::ratio(jnu, Bnu);
   }
   template <typename Emissivity>
-  PORTABLE_INLINE_FUNCTION Real AngleAveragedAbsorptionCoefficientFromKirkhoff(
+  PORTABLE_INLINE_FUNCTION Real AngleAveragedAbsorptionCoefficientFromKirchhoff(
       const Emissivity &J, const Real rho, const Real temp, const Real Ye,
       const RadiationType type, const Real nu, Real *lambda = nullptr) const {
     const Real Bnu =

--- a/singularity-opac/neutrinos/tophat_emissivity_neutrinos.hpp
+++ b/singularity-opac/neutrinos/tophat_emissivity_neutrinos.hpp
@@ -55,7 +55,7 @@ class TophatEmissivity {
   Real AbsorptionCoefficient(const Real rho, const Real temp, const Real Ye,
                              const RadiationType type, const Real nu,
                              Real *lambda = nullptr) const {
-    return dist_.AbsorptionCoefficientFromKirkhoff(*this, rho, temp, Ye, type,
+    return dist_.AbsorptionCoefficientFromKirchhoff(*this, rho, temp, Ye, type,
                                                    nu, lambda) /
            (4. * M_PI);
   }
@@ -78,7 +78,7 @@ class TophatEmissivity {
                                           const RadiationType type,
                                           const Real nu,
                                           Real *lambda = nullptr) const {
-    return dist_.AngleAveragedAbsorptionCoefficientFromKirkhoff(
+    return dist_.AngleAveragedAbsorptionCoefficientFromKirchhoff(
         *this, rho, temp, Ye, type, nu, lambda);
   }
 

--- a/singularity-opac/photons/epbremsstrahlung_opacity_photons.hpp
+++ b/singularity-opac/photons/epbremsstrahlung_opacity_photons.hpp
@@ -53,7 +53,7 @@ class EPBremsstrahlungOpacity {
   PORTABLE_INLINE_FUNCTION
   Real AbsorptionCoefficient(const Real rho, const Real temp, const Real nu,
                              Real *lambda = nullptr) const {
-    return dist_.AbsorptionCoefficientFromKirkhoff(*this, rho, temp, nu,
+    return dist_.AbsorptionCoefficientFromKirchhoff(*this, rho, temp, nu,
                                                    lambda);
   }
 
@@ -71,7 +71,7 @@ class EPBremsstrahlungOpacity {
   Real AngleAveragedAbsorptionCoefficient(const Real rho, const Real temp,
                                           const Real nu,
                                           Real *lambda = nullptr) const {
-    return dist_.AngleAveragedAbsorptionCoefficientFromKirkhoff(
+    return dist_.AngleAveragedAbsorptionCoefficientFromKirchhoff(
         *this, rho, temp, nu, lambda);
   }
 

--- a/singularity-opac/photons/gray_opacity_photons.hpp
+++ b/singularity-opac/photons/gray_opacity_photons.hpp
@@ -49,8 +49,7 @@ class GrayOpacity {
   PORTABLE_INLINE_FUNCTION
   Real AbsorptionCoefficient(const Real rho, const Real temp, const Real nu,
                              Real *lambda = nullptr) const {
-    return dist_.AbsorptionCoefficientFromKirkhoff(*this, rho, temp, nu,
-                                                   lambda);
+    return rho * kappa_;
   }
 
   template <typename FrequencyIndexer, typename DataIndexer>
@@ -67,8 +66,7 @@ class GrayOpacity {
   Real AngleAveragedAbsorptionCoefficient(const Real rho, const Real temp,
                                           const Real nu,
                                           Real *lambda = nullptr) const {
-    return dist_.AngleAveragedAbsorptionCoefficientFromKirkhoff(
-        *this, rho, temp, nu, lambda);
+    return AbsorptionCoefficient(rho, temp, nu, lambda);
   }
 
   template <typename FrequencyIndexer, typename DataIndexer>

--- a/singularity-opac/photons/powerlaw_opacity_photons.hpp
+++ b/singularity-opac/photons/powerlaw_opacity_photons.hpp
@@ -52,8 +52,7 @@ class PowerLawOpacity {
   PORTABLE_INLINE_FUNCTION
   Real AbsorptionCoefficient(const Real rho, const Real temp, const Real nu,
                              Real *lambda = nullptr) const {
-    return dist_.AbsorptionCoefficientFromKirkhoff(*this, rho, temp, nu,
-                                                   lambda);
+    return rho * (kappa0_ * std::pow(rho, rho_exp_) * std::pow(temp, temp_exp_));
   }
 
   template <typename FrequencyIndexer, typename DataIndexer>
@@ -70,8 +69,7 @@ class PowerLawOpacity {
   Real AngleAveragedAbsorptionCoefficient(const Real rho, const Real temp,
                                           const Real nu,
                                           Real *lambda = nullptr) const {
-    return dist_.AngleAveragedAbsorptionCoefficientFromKirkhoff(
-        *this, rho, temp, nu, lambda);
+    return AbsorptionCoefficient(rho, temp, nu, lambda);
   }
 
   template <typename FrequencyIndexer, typename DataIndexer>

--- a/singularity-opac/photons/thermal_distributions_photons.hpp
+++ b/singularity-opac/photons/thermal_distributions_photons.hpp
@@ -74,7 +74,7 @@ struct PlanckDistribution {
     return ThermalNumberDistributionOfT(temp, lambda) / pc::c;
   }
   template <typename Emissivity>
-  PORTABLE_INLINE_FUNCTION Real AbsorptionCoefficientFromKirkhoff(
+  PORTABLE_INLINE_FUNCTION Real AbsorptionCoefficientFromKirchhoff(
       const Emissivity &J, const Real rho, const Real temp, const Real nu,
       Real *lambda = nullptr) const {
     Real Bnu = ThermalDistributionOfTNu(temp, nu, lambda);
@@ -82,7 +82,7 @@ struct PlanckDistribution {
     return singularity_opac::robust::ratio(jnu, Bnu);
   }
   template <typename Emissivity>
-  PORTABLE_INLINE_FUNCTION Real AngleAveragedAbsorptionCoefficientFromKirkhoff(
+  PORTABLE_INLINE_FUNCTION Real AngleAveragedAbsorptionCoefficientFromKirchhoff(
       const Emissivity &J, const Real rho, const Real temp, const Real nu,
       Real *lambda = nullptr) const {
     Real Bnu = ThermalDistributionOfTNu(temp, nu, lambda);


### PR DESCRIPTION
This PR originally started much larger---actually changing all calls from `AbsorptionCoefficient` to `SpecificAbsorptionOpacity`.  After some retrospection, a simple change of mindset got me on board with instead dealing with absorption coefficients.  I'd like to discuss this via meeting.

After this realization, this PR shrunk to only changing out some calls to `AbsorptionCoefficient` to directly returning rho * kappa (where rho is the material density and kappa is the material specific absorption opacity), instead of arriving there via Kirchhoff's laws.  

I kept the functions for `*FromKirchhoff` in this PR for photons, even though they are not used, as I think they do help guide readers of the code as to what things correspond to.  Neutrinos also have calls to `*FromKirchhoff` (e.g., for the tophat absorption coefficient), but I did not edit these (was this the right move?).