### PR TITLE
Another modification to constants comparison

### DIFF
--- a/singularity-opac/constants/constants.hpp
+++ b/singularity-opac/constants/constants.hpp
@@ -265,10 +265,12 @@ struct RuntimePhysicalConstants {
     return is_same;
   }
 
-  private:
-   bool eps_equal(const Real &a, const Real &b) const {
-     return 2.0 * std::abs(a - b) < EPS * (std::abs(a) + std::abs(b) + 1e-100);
-   }
+ private:
+  bool eps_equal(const Real &a, const Real &b) const {
+    const Real diff = std::abs(a - b);
+    const Real scale = 0.5 * (std::abs(a) + std::abs(b));
+    return diff / (scale + 1e-100) <= EPS;
+  }
 };
 
 using PhysicalConstantsUnity =


### PR DESCRIPTION
Debug build of artemis crashed in the constants comparison (of `h` specifically). Seemed like a stupid floating point problem that was solved by making the comparison `<=` instead of `<`. I also went ahead and split out the difference and scale into separate variables for possible future debugging. 